### PR TITLE
Fixing docusaurus nav link icon alignment 

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -34,6 +34,12 @@
   @apply text-white dark:text-gray-50;
 }
 
+.navbar__link svg,
+.footer__item svg {
+  display: inline;
+  margin-left: 12px;
+}
+
 /* -------------- */
 /* Font Configuration */
 /* ------------- */


### PR DESCRIPTION
- The nav link icon doesn't drop to the next line anymore