### PR TITLE
Add CNCF copyright footer text

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -169,7 +169,7 @@ const config = {
             ],
           },
         ],
-        copyright: `Copyright © ${new Date().getFullYear()} Podman. Built with Docusaurus.`,
+        copyright: `Built with Docusaurus<br />Copyright © Podman Container Tools a Series of LF Projects, LLC<br />For website terms of use, trademark policy and other project policies please see lfprojects.org/policies`,
       },
 
       prism: {


### PR DESCRIPTION
## Description

Adds a copyright field with the text required by the Linux Foundation. Feel free to move this or style it differently if needed (for example, I removed the inline link to lfprojects.org/policies as it was inheriting a larger font size for the `a` tags in the rest of the footer).

## Related Issue

https://github.com/cncf/sandbox/issues/338

## Motivation and Context

This adds the copyright field mentioned on the CNCF onboarding checklist issue above and outlined in the Contribution Agreement instructions doc.

## Preview

<img width="1083" height="367" alt="image" src="https://github.com/user-attachments/assets/d8eb8d54-4641-48f3-81fe-3011d5395580" />
