### PR TITLE
Change meeting links

### DIFF
--- a/static/data/community.ts
+++ b/static/data/community.ts
@@ -1,3 +1,4 @@
+import { CABAL_MEETING_URL } from './global';
 import { MEETING_URL } from './global';
 const header = {
   title: 'Community',
@@ -71,7 +72,7 @@ const communityMeetings = {
       date: '**1st Tuesday** of odd numbered months',
       timeZone: '11 AM US ET /5 PM CET',
       buttons: [
-        { text: 'Join Meeting', path: MEETING_URL },
+        { text: 'Join Meeting', path: CABAL_MEETING_URL },
         { text: 'Meeting Agenda', path: 'https://hackmd.io/gQCfskDuRLm7iOsWgH2yrg?both' },
       ],
     },

--- a/static/data/global.ts
+++ b/static/data/global.ts
@@ -1,5 +1,6 @@
 export const LATEST_VERSION = '5.6.0';
 export const LATEST_DESKTOP_VERSION = '1.21.0';
 export const LATEST_DESKTOP_DOWNLOAD_URL = 'https://podman-desktop.io/blog/podman-desktop-release-1.21';
-export const MEETING_URL = 'https://meet.google.com/xrq-uemd-bzy';
+export const MEETING_URL = 'https://zoom-lfx.platform.linuxfoundation.org/meeting/97486138230?password=3144ae43-0fd5-457e-a495-bb4e0202e9c2';
+export const CABAL_MEETING_URL = 'https://zoom-lfx.platform.linuxfoundation.org/meeting/96844452039?password=cc6cf3da-6a3b-437b-88d4-d1c233ffd352';
 export const RELEASE_NOTES = '';


### PR DESCRIPTION
The meeting links for the Podman Community Meeting and the Podman Cabal meeting now have different URL's and have moved to Zoom.

Change to the new links and create a new variable to allow for the separate links.