### PR TITLE
minor: fix padding on home page

### DIFF
--- a/src/components/content/ColoringBookSection/index.tsx
+++ b/src/components/content/ColoringBookSection/index.tsx
@@ -6,7 +6,7 @@ function ColoringBookSection() {
     <section className="container my-12 flex flex-wrap justify-center gap-4 lg:justify-start xl:my-20">
       <div className="flex">
         <div className="mx-4 flex-col items-center text-center lg:mx-0 lg:items-start lg:text-start">
-          <h2 className="my-4 font-medium text-blue-900 dark:text-blue-500">{data.title}</h2>
+          <h2 className="my-4 p-0 font-medium text-blue-900 dark:text-blue-500">{data.title}</h2>
           <p className="mb-4 max-w-prose lg:mb-10">{data.description}</p>
           <Button
             as="link"


### PR DESCRIPTION
"Have fun coloring and learn about Podman!"

## Before

<img width="1041" height="345" alt="image" src="https://github.com/user-attachments/assets/edcdf482-e53f-40ac-804f-f2b0dca6269d" /> 

## After

<img width="1034" height="351" alt="image" src="https://github.com/user-attachments/assets/9e3ccdc4-926d-43ed-a6f4-e54e55fa23ac" /> 