### PR TITLE
docs: fix typo in Submitting Pull Requests section

### DIFF
--- a/static/data/community.ts
+++ b/static/data/community.ts
@@ -186,7 +186,7 @@ const submittingIssues = [
     ],
     checkList: [
       'Well-documented code changes.',
-      'Additional testcases. Ideally m they should fail w/o your code change applied.',
+      'Additional testcases. Ideally, they should fail w/o your code change applied.',
       'Documentation changes.',
     ],
     button: {


### PR DESCRIPTION
This PR fixes a typo in the “Submitting Pull Requests” section of the community page.
Replaced “Ideally m” with “Ideally, they” to correct the sentence and improve clarity.