### PR TITLE
Add RFC 9116 security.txt to static/.well-known/

### DIFF
--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,0 +1,6 @@
+# podman security contact — see https://github.com/containers/common/blob/main/SECURITY.md
+Contact: mailto:security@lists.podman.io
+Expires: 2027-07-14T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://podman.io/.well-known/security.txt
+Policy: https://github.com/containers/common/blob/main/SECURITY.md


### PR DESCRIPTION
## What this does

Adds `/.well-known/security.txt` by placing it in `static/.well-known/security.txt`, which Docusaurus copies verbatim to the published site root.

## Why

[RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) defines a standard file at `/.well-known/security.txt` so a security researcher can find where to report a vulnerability. Right now the live file is missing:

```
$ curl -sSL -o /dev/null -w '%{http_code}\n' https://podman.io/.well-known/security.txt
404
```

The project already has a security contact — I just pointed the file at it rather than inventing anything:

- `Contact: mailto:security@lists.podman.io` (from the [Containers security policy](https://github.com/containers/common/blob/main/SECURITY.md) that this repo's `SECURITY.md` defers to)
- `Policy:` the same Containers security policy
- `Expires:` — RFC 9116 requires this field; I set it ~1 year out.

## Verifying it will serve

`static/` is already served verbatim (it has `.nojekyll` + `CNAME`) — e.g. `static/favicon.ico` is live at `https://podman.io/favicon.ico` (200). So `static/.well-known/security.txt` will publish at `https://podman.io/.well-known/security.txt`. Please double-check on a preview build.

Single file, no other changes. Commit is DCO signed-off.

---

*Disclosure: I used an AI tool to help spot this and draft the file. I verified every line myself against the live site and the security policy, and I take responsibility for the change. Happy to adjust the `Expires` date, contact, or policy link to whatever you prefer.*
