### PR TITLE
Fix terminal command overflow on get-started page

### DIFF
--- a/src/pages/get-started.tsx
+++ b/src/pages/get-started.tsx
@@ -75,7 +75,7 @@ const RunListContainersSection = () => {
         <h3 className="text-purple-700 dark:text-purple-300 mb-2 mt-10">Running a container</h3>
 
         <div className="mx-auto">
-          <CodeBlock language="bash" showLineNumbers className="text-left overflow-scroll max-w-full">
+          <CodeBlock language="bash" showLineNumbers className="text-left overflow-scroll xl:max-w-6xl max-w-xs sm:max-w-md md:max-w-lg lg:max-w-4xl">
             $ podman run -dt -p 8080:80/tcp docker.io/library/httpd {'\n'}
           </CodeBlock>
         </div>


### PR DESCRIPTION
The CodeBlock component's overflow-scroll behavior wasn't backed by a  max-width constraint, so on narrower screens the block rendered at its full content width instead of scrolling horizontally, pushing the page wider than its frame.