### PR TITLE
fix: correct carousel text for Run and Build tabs

### DIFF
--- a/src/components/content/FeaturesCarousel/data.ts
+++ b/src/components/content/FeaturesCarousel/data.ts
@@ -15,7 +15,7 @@ const tabData = [
     title: 'Run pre-built application or distro containers.',
     commands: ['podman run'],
     description:
-      'Find and pull down containers whether they are on dockerhub.io or quay.io, an internal registry server, or direct from a vendor.',
+      'Run containers using images pulled from a registry, or from images you build yourself. Podman lets you run containers as a regular user or as root.',
     image: {
       src: 'images/raw/cli-screens/cli-run-image.png',
       alt: 'example of podman commands',
@@ -23,10 +23,10 @@ const tabData = [
   },
   {
     label: 'Build',
-    title: 'Podman Troubleshooting Guide ',
+    title: 'Build container images from a Containerfile.',
     commands: ['podman build'],
     description:
-      'Find and pull down containers whether they are on dockerhub.io or quay.io, an internal registry server, or direct from a vendor.',
+      'Build OCI and Docker-compatible container images using a Containerfile or Dockerfile — no daemon required.',
     image: {
       src: 'images/raw/cli-screens/cli-build-image.png',
       alt: 'example of podman commands',


### PR DESCRIPTION
## Description

Fixes #230 — the **"Podman Command-Line"** carousel on the Features page (`src/components/content/FeaturesCarousel/data.ts`) had incorrect text for the **Run** and **Build** tabs.

## Changes

* **Run:** Fixed the description, which was incorrectly showing the **Find** tab's description.
* **Build:** Fixed the title, which was showing **"Podman Troubleshooting Guide"** instead of a Build-related title, and corrected the description, which was also duplicated from **Find**.
* **Find** and **Share:** Left unchanged, as their text is already correct.

## Note on Screenshots

While investigating the issue, I noticed that `cli-run-image.png`, `cli-build-image.png`, and `cli-share-image.png` are currently identical placeholder images (539×426px) showing generic `$ podman --help` output. In contrast, `cli-find-image.png` contains actual, command-specific output for **Find**.

This appears to be separate from the text issue addressed in this PR. The file paths and references in `data.ts` are correct, but the underlying image assets would need to be replaced with appropriate screenshots for `podman run`, `podman build`, and `podman push`.

**Question for maintainers:** Do you already have reference screenshots for these three commands, or would you prefer that I generate and submit new ones in a follow-up PR? I'm happy to match the style and terminal theme used in the existing **Find** screenshot.

## Testing

* Ran `yarn start` and verified all four carousel tabs locally.
* Confirmed that only `data.ts` was modified; no other files were changed.
