### PR TITLE
refactor: componentize blog articles list 

### DIFF
--- a/src/components/content/BlogArticlesList/index.tsx
+++ b/src/components/content/BlogArticlesList/index.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import SectionHeader from '@site/src/components/layout/SectionHeader';
+import ArticleCard from '@site/src/components/ui/ArticleCard';
+import { useBlogPosts } from '@site/src/hooks/useBlogPosts';
+
+interface BlogArticlesListProps {
+  limit?: number;
+  displayCount?: number;
+  altLayout?: boolean;
+  title?: string;
+  titleColor?: string;
+  showFooter?: boolean;
+  footerText?: string;
+  containerLayout?: 'vertical' | 'grid';
+  sectionClassName?: string;
+}
+
+const BlogArticlesList: React.FC<BlogArticlesListProps> = ({
+  limit = 4,
+  displayCount,
+  altLayout = false,
+  title = 'Latest Articles',
+  titleColor = 'text-blue-700',
+  showFooter = false,
+  footerText = '',
+  containerLayout = 'grid',
+  sectionClassName = '',
+}) => {
+  const { data, loading } = useBlogPosts(limit);
+  const actualDisplayCount = displayCount ?? limit;
+
+  if (loading) {
+    return null;
+  }
+
+  const containerClasses =
+    containerLayout === 'vertical' ? 'flex flex-col gap-4' : 'flex flex-wrap justify-center gap-4';
+
+  return (
+    <section className={sectionClassName}>
+      <SectionHeader title={title} textColor={titleColor} />
+      <div className={containerClasses}>
+        {data.slice(0, actualDisplayCount).map((card, index) => (
+          <ArticleCard
+            key={card.id}
+            title={card.title.rendered}
+            author_link={card.author_info.author_link}
+            display_name={card.author_info.display_name}
+            subtitle={card.excerpt.rendered}
+            date={card.wbDate}
+            imgSrc={card.jetpack_featured_media_url}
+            path={card.link}
+            altLayout={altLayout}
+            index={index}
+          />
+        ))}
+      </div>
+      {showFooter && footerText && (
+        <p className="ml-2l text-center 2xl:text-start">
+          {footerText}{' '}
+          <a
+            href="https://blog.podman.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline-offset-4 transition duration-150 ease-linear hover:text-purple-700 dark:hover:text-purple-500">
+            on our Blog!
+          </a>
+        </p>
+      )}
+    </section>
+  );
+};
+
+export default BlogArticlesList;

--- a/src/components/ui/ArticleCard/index.tsx
+++ b/src/components/ui/ArticleCard/index.tsx
@@ -9,7 +9,15 @@ type ArticleCardProps = {
   imgSrc?: string;
   altLayout?: boolean;
   path: string;
+  index?: number;
 };
+
+const FALLBACK_IMAGES = [
+  'images/raw/characters/seal-diving.png',
+  'images/raw/characters/seals-swimming.png',
+  'images/raw/characters/confused-seal.png',
+  'images/raw/podman-selkie-385w-358h.png',
+];
 
 const PublishDate = ({ date, styles }: { date: string; styles?: string }) => {
   return (
@@ -24,6 +32,9 @@ const Title = (title: string) => {
 };
 
 function ArticleCard(props: ArticleCardProps) {
+  // Select fallback image based on index, cycling through available images
+  const fallbackImage = FALLBACK_IMAGES[(props.index || 0) % FALLBACK_IMAGES.length];
+  
   // Sanitizes HTML and converts it to plain text
   const sanitizeHtml = (html: string) => {
     if (!html) return html;
@@ -49,7 +60,7 @@ function ArticleCard(props: ArticleCardProps) {
               <PublishDate date={props.date} styles="col-start-1 order-1 row-start-1 z-10" />
             </div>
             <img
-              src={props.imgSrc}
+              src={props.imgSrc || fallbackImage}
               className=" col-start-1 row-start-1 h-full w-full rounded-sm object-cover lg:w-80"
             />
           </div>
@@ -78,7 +89,7 @@ function ArticleCard(props: ArticleCardProps) {
           </h3>
           {parse(abbrSubtitle)}
           <PublishDate date={props.date} styles="row-start-1 col-start-1 z-10 my-2" />
-          <img src={props.imgSrc} className="object-fit col-start-1 row-start-1 rounded-sm" />
+          <img src={props.imgSrc || fallbackImage} className="object-fit col-start-1 row-start-1 rounded-sm" />
           <p className="text-purple-700">
             By: <a href={props.author_link}>{props.display_name}</a>
           </p>

--- a/src/hooks/useBlogPosts.ts
+++ b/src/hooks/useBlogPosts.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react';
+
+interface BlogPost {
+  id: number;
+  title: {
+    rendered: string;
+  };
+  author_info: {
+    author_link: string;
+    display_name: string;
+  };
+  wbDate: string;
+  jetpack_featured_media_url: string;
+  link: string;
+  excerpt: {
+    rendered: string;
+  };
+}
+
+interface UseBlogPostsReturn {
+  data: BlogPost[];
+  loading: boolean;
+}
+
+export const useBlogPosts = (limit: number = 4): UseBlogPostsReturn => {
+  const [data, setData] = useState<BlogPost[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const rawData = await fetch(
+          `https://blog.podman.io/wp-json/wp/v2/posts?per_page=${limit}&_fields=id,author_info,title,wbDate,jetpack_featured_media_url,link,excerpt`,
+        );
+        const jsonData = await rawData.json();
+        setData(jsonData);
+      } catch (error) {
+        console.error(error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [limit]);
+
+  return { data, loading };
+};

--- a/src/pages/features.tsx
+++ b/src/pages/features.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Layout from '@theme/Layout';
 import { Icon } from '@iconify/react';
 /* COMPONENTS */
@@ -6,8 +6,8 @@ import Markdown from '@site/src/components/utilities/Markdown';
 import PageHeader from '@site/src/components/layout/PageHeader';
 import SectionHeader from '@site/src/components/layout/SectionHeader';
 import ColoringBookSection from '@site/src/components/content/ColoringBookSection';
-import ArticleCard from '@site/src/components/ui/ArticleCard';
 import FeaturesCarousel from '@site/src/components/content/FeaturesCarousel';
+import BlogArticlesList from '@site/src/components/content/BlogArticlesList';
 /* PAGE DATA */
 import { header, knowPodman, learnMore } from '@site/static/data/features';
 import PlayOnScroll from '@site/src/components/utilities/PlayOnScroll';
@@ -170,63 +170,22 @@ const PodmanCLISection = () => {
   );
 };
 
-/* TODO Should be componentized at some point */
-const LearnArticles = () => {
-  const [blogData, setBlogData] = useState([]);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const rawData = await fetch(
-        'https://blog.podman.io/wp-json/wp/v2/posts?per_page=4&_fields=id, author_info, title, wbDate, jetpack_featured_media_url, link, excerpt',
-      );
-      const jsonData = await rawData.json();
-      setBlogData(jsonData);
-    };
-    fetchData().catch(console.error);
-  }, []);
-  return (
-    <section className="my-4 lg:my-0">
-      <header className="container mb-4 text-center lg:mb-8 lg:text-start">
-        <h3 className="font-medium text-blue-700 dark:text-blue-500">{learnMore.blogPosts.title}</h3>
-      </header>
-      <div className="flex flex-col gap-4">
-        {blogData.map((card, index) => {
-          if (index < 2) {
-            return (
-              <ArticleCard
-                title={card.title.rendered}
-                author_link={card.author_info.author_link}
-                display_name={card.author_info.display_name}
-                subtitle={card.excerpt.rendered}
-                date={card.wbDate}
-                imgSrc={card.jetpack_featured_media_url}
-                path={card.link}
-                altLayout
-                key={card.id}
-              />
-            );
-          }
-        })}
-        <p className="ml-2l text-center 2xl:text-start">
-          Check out more posts about Podman{' '}
-          <a
-            href="https://blog.podman.io"
-            target="_blank"
-            className="underline-offset-4 transition duration-150 ease-linear hover:text-purple-700 dark:hover:text-purple-500">
-            on our Blog!
-          </a>
-        </p>
-      </div>
-    </section>
-  );
-};
-
 const LearnMoreSection = () => {
   return (
     <section>
       <SectionHeader title={learnMore.title} textGradient={true} textGradientStops="from-purple-500 to-purple-900" />
       <div className="container mt-8 flex flex-wrap justify-center gap-24">
-        <LearnArticles />
+        <BlogArticlesList
+          limit={2}
+          displayCount={2}
+          altLayout
+          title={learnMore.blogPosts.title}
+          titleColor="text-blue-700 dark:text-blue-500"
+          showFooter
+          footerText="Check out more posts about Podman"
+          containerLayout="vertical"
+          sectionClassName="my-4 lg:my-0"
+        />
         <BasicResourcesBox />
       </div>
     </section>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import Layout from '@theme/Layout';
 /* COMPONENTS */
 import Markdown from '@site/src/components/utilities/Markdown';
@@ -6,9 +6,9 @@ import HeroHeader from '@site/src/components/layout/HeroHeader';
 import SectionHeader from '@site/src/components/layout/SectionHeader';
 import InfoBanner from '@site/src/components/ui/InfoBanner';
 import ThumbCard from '@site/src/components/ui/ThumbCard';
-import ArticleCard from '@site/src/components/ui/ArticleCard';
 import ColoringBookSection from '@site/src/components/content/ColoringBookSection';
 import TestimonialSection from '@site/src/components/content/TestimonialSection';
+import BlogArticlesList from '@site/src/components/content/BlogArticlesList';
 /* PAGE DATA */
 import { header, featureList, kubernetesBanner, compatibleTools } from '@site/static/data/home';
 
@@ -47,42 +47,6 @@ const CompatibleToolSection = () => {
   );
 };
 
-const LatestNews = () => {
-  const [blogData, setBlogData] = useState([]);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const rawData = await fetch(
-        'https://blog.podman.io/wp-json/wp/v2/posts?per_page=4&_fields=id, author_info, title, wbDate, jetpack_featured_media_url, link, excerpt',
-      );
-      const jsonData = await rawData.json();
-      setBlogData(jsonData);
-    };
-    fetchData().catch(console.error);
-  }, []);
-  return (
-    <section>
-      <SectionHeader title="Latest Podman News" textColor="text-purple-700" />
-      <div className="flex flex-wrap justify-center gap-4">
-        {blogData.map(card => {
-          return (
-            <ArticleCard
-              title={card.title.rendered}
-              author_link={card.author_info.author_link}
-              display_name={card.author_info.display_name}
-              subtitle={card.excerpt.rendered}
-              date={card.wbDate}
-              imgSrc={card.jetpack_featured_media_url}
-              path={card.link}
-              key={card.id}
-            />
-          );
-        })}
-      </div>
-    </section>
-  );
-};
-
 /* PAGE CONTENT */
 function IndexPage() {
   return (
@@ -92,7 +56,7 @@ function IndexPage() {
       <InfoBanner {...kubernetesBanner} />
       <CompatibleToolSection />
       <TestimonialSection />
-      <LatestNews />
+      <BlogArticlesList limit={4} title="Latest Podman News" titleColor="text-purple-700" containerLayout="grid" />
       <ColoringBookSection />
     </Layout>
   );


### PR DESCRIPTION
## Description

Moves the duplicated blog post logic from the Features and Homepage into a shared hook and component.

This also resolves the TODO in `src/pages/features.tsx` about moving this into a component. There should be no change in the existing behaviour.

## Changes

* Added `src/hooks/useBlogPosts.ts` for fetching blog posts with a configurable limit.
* Added `BlogArticlesList` as a shared component for displaying the articles.
* Updated `features.tsx` and `index.tsx` to use the shared component instead of having separate implementations.

## Issues noticed while testing

@TomSweeneyRedHat @ashley-cui, I also noticed a couple of existing UI issues while testing:

* Some blog posts have blank thumbnails because `jetpack_featured_media_url` is empty for them.
* Cards without thumbnails are shorter, which causes uneven alignment in the "Latest Podman News" section.

I fixed the missing thumbnail case in this PR, but left the card alignment as-is to keep the changes focused. I can open a separate issue for that.
