### PR TITLE
docs: update Podman and Podman Desktop GitHub links in footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -152,11 +152,11 @@ const config = {
             items: [
               {
                 label: 'Podman GitHub',
-                href: 'https://github.com/containers/podman',
+                href: 'https://github.com/podman-container-tools/podman',
               },
               {
                 label: 'Podman Desktop GitHub',
-                href: 'https://github.com/containers/podman-desktop',
+                href: 'https://github.com/podman-desktop/podman-desktop',
               },
               {
                 label: 'Podman Website GitHub',


### PR DESCRIPTION
### Description

This PR updates the GitHub repository links in the website's footer to point to their new respective organisations. 

Specifically:
- Updated the Podman link to `podman-container-tools` (Fixes #511 )
- Updated the Podman Desktop link to `podman-desktop`

While GitHub handles 301 redirects for transferred repositories, this updates the website to reflect the official link. As noted in #511, this also prevents third-party tools (like AI bots or link checkers) from flagging the discrepancy as suspicious.

### Note
While looking into this, I noticed there are several other occurrences of the old `https://github.com/containers/podman` URL scattered throughout the codebase.
Should those be replaced aswell?

### Related Issue
Fixes #511