### PR TITLE
fix: add accessible labels to icon-only carousel navigation buttons

### DIFF
--- a/src/components/content/FeaturesCarousel/index.tsx
+++ b/src/components/content/FeaturesCarousel/index.tsx
@@ -84,7 +84,10 @@ function FeaturesCarousel() {
             : 'bg-gradient-to-br from-purple-300 via-purple-700 to-purple-900'
         }`}>
         <div className="space-between container flex">
-          <button onClick={() => setActiveTabIndex(activeTabIndex > 0 ? activeTabIndex - 1 : tabData.length - 1)}>
+          <button
+            type="button"
+            onClick={() => setActiveTabIndex(activeTabIndex > 0 ? activeTabIndex - 1 : tabData.length - 1)}
+            aria-label="Previous feature">
             <Icon
               icon="fa-solid:arrow-circle-left"
               className={`text-3xl transition duration-150 ease-linear hover:opacity-50 dark:hover:opacity-50  ${
@@ -93,7 +96,10 @@ function FeaturesCarousel() {
             />
           </button>
           <TabContent {...tabData[activeTabIndex]} isActive={activeTabIndex} />
-          <button onClick={() => setActiveTabIndex(activeTabIndex < 3 ? activeTabIndex + 1 : 0)}>
+          <button
+            type="button"
+            onClick={() => setActiveTabIndex(activeTabIndex < 3 ? activeTabIndex + 1 : 0)}
+            aria-label="Next feature">
             <Icon
               icon="fa-solid:arrow-circle-right"
               className={`text-3xl transition duration-150 ease-linear hover:text-purple-900 dark:hover:text-purple-700 ${

--- a/src/components/content/TestimonialSection/index.tsx
+++ b/src/components/content/TestimonialSection/index.tsx
@@ -21,7 +21,11 @@ function TestimonialSection() {
         textGradientStops="from-blue-700 to-blue-500"
       />
       <div className="container relative mx-auto my-8 flex items-center justify-center">
-        <button onClick={slideLeft} className="hidden sm:block xl:hidden">
+        <button
+          type="button"
+          onClick={slideLeft}
+          className="hidden sm:block xl:hidden"
+          aria-label="Previous testimonial">
           <Icon
             icon="fa-solid:arrow-circle-left"
             className="text-4xl text-gray-500 opacity-25 transition duration-150 ease-linear hover:text-purple-900 hover:opacity-100 dark:hover:text-purple-700"
@@ -34,7 +38,11 @@ function TestimonialSection() {
             return <Testimonial key={index} {...testimonial} />;
           })}
         </div>
-        <button onClick={slideRight} className="hidden sm:block xl:hidden">
+        <button
+          type="button"
+          onClick={slideRight}
+          className="hidden sm:block xl:hidden"
+          aria-label="Next testimonial">
           <Icon
             icon="fa-solid:arrow-circle-right"
             className="dark:hover-text-purple-700 text-4xl text-gray-500 opacity-25 transition duration-150 ease-linear hover:text-purple-900 hover:opacity-100"

--- a/src/components/content/ThankYouSection/index.tsx
+++ b/src/components/content/ThankYouSection/index.tsx
@@ -21,7 +21,7 @@ function ThankYouSection(): JSX.Element {
         </p>
       </header>
       <div className="relative mx-auto my-8 flex items-center">
-        <button onClick={slideLeft} className="lg:hidden">
+        <button type="button" onClick={slideLeft} className="lg:hidden" aria-label="Previous contributor">
           <Icon
             icon="fa-solid:arrow-circle-left"
             className="text-4xl text-gray-500 opacity-25 transition duration-150 ease-linear hover:text-purple-900 hover:opacity-100 dark:hover:text-purple-700"
@@ -73,7 +73,7 @@ function ThankYouSection(): JSX.Element {
             <img {...debian} className="mx-auto p-4" />
           </a>
         </div>
-        <button onClick={slideRight} className="lg:hidden">
+        <button type="button" onClick={slideRight} className="lg:hidden" aria-label="Next contributor">
           <Icon
             icon="fa-solid:arrow-circle-right"
             className="dark:hover-text-purple-700 text-4xl text-gray-500 opacity-25 transition duration-150 ease-linear hover:text-purple-900 hover:opacity-100"


### PR DESCRIPTION
## Summary

This PR improves the accessibility of the carousel navigation controls by adding descriptive `aria-label` attributes to icon-only navigation buttons.

Without an accessible name, these controls may not provide meaningful information to users of assistive technologies such as screen readers.

## Changes

Added descriptive `aria-label` attributes to the navigation buttons in:

- `FeaturesCarousel`
- `ThankYouSection`
- `TestimonialSection`

The labels describe the action performed by each control (for example, "Previous feature" and "Next testimonial") rather than the icon itself, making the controls more understandable for screen reader users.

## Why

Icon-only buttons should have an accessible name so that assistive technologies can accurately communicate their purpose.

This change improves accessibility while preserving the existing UI, styling, animations, and functionality.

## Testing

- [x] Built successfully using `yarn build`
- [x] Verified that there are no visual changes
- [x] Verified that existing functionality remains unchanged