### PR TITLE
Update footer GitHub links to current org locations

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -152,11 +152,11 @@ const config = {
             items: [
               {
                 label: 'Podman GitHub',
-                href: 'https://github.com/containers/podman',
+                href: 'https://github.com/podman-container-tools/podman',
               },
               {
                 label: 'Podman Desktop GitHub',
-                href: 'https://github.com/containers/podman-desktop',
+                href: 'https://github.com/podman-desktop/podman-desktop',
               },
               {
                 label: 'Podman Website GitHub',


### PR DESCRIPTION
Fixes #511 by updating the footer Podman GitHub and Podman Desktop GitHub links to point at the current org locations (podman-container-tools/podman and podman-desktop/podman-desktop).