### PR TITLE
Bump @iconify/react to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@docusaurus/plugin-content-blog": "^2.4.1",
     "@docusaurus/preset-classic": "^2.4.1",
     "@docusaurus/theme-live-codeblock": "^2.4.1",
-    "@iconify/react": "^4.0.1",
+    "@iconify/react": "^6",
     "@mdx-js/react": "^1.6.22",
     "autoprefixer": "^10.4.13",
     "clsx": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2392,14 +2392,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@iconify/react@npm:^4.0.1":
-  version: 4.1.1
-  resolution: "@iconify/react@npm:4.1.1"
+"@iconify/react@npm:^6":
+  version: 6.0.2
+  resolution: "@iconify/react@npm:6.0.2"
   dependencies:
     "@iconify/types": ^2.0.0
   peerDependencies:
     react: ">=16"
-  checksum: 43b71a0eb4312cf0fa7412b568369e75b8a327b8b7d9fc3dce42b2d047326e39dd17541a8d915fb80b87b20a56eba1a9b52304410624b5814fdf3ad17da9196a
+  checksum: 8038cf3cc064a060dba3f794e4790a1d00c24350ff5fa1aabe94eb9ac1e5795cb2a81ac74928bd75e38878136f3244c5473d2aa579bf3144e92846cec8bb97a4
   languageName: node
   linkType: hard
 
@@ -9631,7 +9631,7 @@ __metadata:
     "@docusaurus/plugin-content-blog": ^2.4.1
     "@docusaurus/preset-classic": ^2.4.1
     "@docusaurus/theme-live-codeblock": ^2.4.1
-    "@iconify/react": ^4.0.1
+    "@iconify/react": ^6
     "@mdx-js/react": ^1.6.22
     "@tsconfig/docusaurus": ^1.0.5
     "@typescript-eslint/eslint-plugin": ^5.48.2


### PR DESCRIPTION
Summary

Bumps @iconify/react from v4 to v6, one of the outdated dependencies flagged in the Renovate Dependency Dashboard in #159.

The repo only uses the basic Icon component with a string icon prop (17 usages across src), and that API is unchanged between v4 and v6, so no code changes are needed. The peer dependency range for react also still covers the project's React 17.

Test plan

Ran yarn build locally and confirmed it completes successfully.