### PR TITLE
Bump prism-react-renderer to v2

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,7 +1,8 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
-const lightCodeTheme = require('prism-react-renderer/themes/github');
-const darkCodeTheme = require('prism-react-renderer/themes/dracula');
+const { themes } = require('prism-react-renderer');
+const lightCodeTheme = themes.github;
+const darkCodeTheme = themes.dracula;
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "html-react-parser": "^3.0.16",
     "papaparse": "^5.4.1",
     "postcss": "^8.4.21",
-    "prism-react-renderer": "^1.3.5",
+    "prism-react-renderer": "^2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-markdown": "^8.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,6 +3088,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prismjs@npm:^1.26.0":
+  version: 1.26.6
+  resolution: "@types/prismjs@npm:1.26.6"
+  checksum: b61abb7370d55b549ab67d1dfab479f1f27539cebe02f051db67f0ad90f5de34df6b9fcaf340dd2f3e0217bba15d3e31c642832560ecf1779397d6950ee69478
+  languageName: node
+  linkType: hard
+
 "@types/prop-types@npm:*, @types/prop-types@npm:^15.0.0":
   version: 15.7.8
   resolution: "@types/prop-types@npm:15.7.8"
@@ -4602,6 +4609,13 @@ __metadata:
   version: 1.2.1
   resolution: "clsx@npm:1.2.1"
   checksum: 30befca8019b2eb7dbad38cff6266cf543091dae2825c856a62a8ccf2c3ab9c2907c4d12b288b73101196767f66812365400a227581484a05f968b0307cfaf12
+  languageName: node
+  linkType: hard
+
+"clsx@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "clsx@npm:2.1.1"
+  checksum: acd3e1ab9d8a433ecb3cc2f6a05ab95fe50b4a3cfc5ba47abb6cbf3754585fcb87b84e90c822a1f256c4198e3b41c7f6c391577ffc8678ad587fc0976b24fd57
   languageName: node
   linkType: hard
 
@@ -9647,7 +9661,7 @@ __metadata:
     postcss: ^8.4.21
     prettier: 2.8.8
     prettier-plugin-tailwindcss: ^0.8.0
-    prism-react-renderer: ^1.3.5
+    prism-react-renderer: ^2
     react: ^17.0.2
     react-dom: ^17.0.2
     react-markdown: ^8.0.5
@@ -10274,6 +10288,18 @@ __metadata:
   peerDependencies:
     react: ">=0.14.9"
   checksum: c18806dcbc4c0b4fd6fd15bd06b4f7c0a6da98d93af235c3e970854994eb9b59e23315abb6cfc29e69da26d36709a47e25da85ab27fed81b6812f0a52caf6dfa
+  languageName: node
+  linkType: hard
+
+"prism-react-renderer@npm:^2":
+  version: 2.4.1
+  resolution: "prism-react-renderer@npm:2.4.1"
+  dependencies:
+    "@types/prismjs": ^1.26.0
+    clsx: ^2.0.0
+  peerDependencies:
+    react: ">=16.0.0"
+  checksum: ddd5490a1335629addde9535db7872f0aee8dbce048818dd6e4c3972c779780af13d669c12d3f2fbb54c5b22d1578e50945099ef1a24dd445f33774e87d85e6e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Summary

Bumps prism-react-renderer from v1 to v2, one of the outdated dependencies flagged in the Renovate Dependency Dashboard in #159.

This one needed a small code change. The v2 package removed the themes/* subpath files and instead exports a themes object from its main module, so docusaurus.config.js now does const { themes } = require('prism-react-renderer') and reads themes.github and themes.dracula.

Note on scope

Docusaurus 2.4's own theme-classic and theme-common packages still depend on prism-react-renderer v1.3.5 internally for their own CodeBlock rendering. Since this repo uses the node-modules linker, yarn keeps a separate nested v1.3.5 copy inside those packages, so this bump only affects our own direct usage in docusaurus.config.js and does not touch how Docusaurus renders code blocks internally.

Test plan

Ran yarn build locally and confirmed it completes successfully.
Ran the dev server and visually confirmed code blocks on the installation docs page still render with correct syntax highlighting colors after the theme import change.