### PR TITLE
fix(ui): resolve broken images in ArticleCard component

### DIFF
--- a/src/components/ui/ArticleCard/index.tsx
+++ b/src/components/ui/ArticleCard/index.tsx
@@ -49,7 +49,10 @@ function ArticleCard(props: ArticleCardProps) {
               <PublishDate date={props.date} styles="col-start-1 order-1 row-start-1 z-10" />
             </div>
             <img
-              src={props.imgSrc}
+              src={props.imgSrc || 'logos/optimized/podman-3-logo-266w-253h.webp'}
+              onError={(e) => {
+                e.currentTarget.src = 'logos/optimized/podman-3-logo-266w-253h.webp';
+              }}
               className=" col-start-1 row-start-1 h-full w-full rounded-sm object-cover lg:w-80"
             />
           </div>
@@ -78,7 +81,13 @@ function ArticleCard(props: ArticleCardProps) {
           </h3>
           {parse(abbrSubtitle)}
           <PublishDate date={props.date} styles="row-start-1 col-start-1 z-10 my-2" />
-          <img src={props.imgSrc} className="object-fit col-start-1 row-start-1 rounded-sm" />
+          <img 
+            src={props.imgSrc || 'logos/optimized/podman-3-logo-266w-253h.webp'} 
+            onError={(e) => {
+              e.currentTarget.src = 'logos/optimized/podman-3-logo-266w-253h.webp';
+            }}
+            className="object-fit col-start-1 row-start-1 rounded-sm" 
+          />
           <p className="text-purple-700">
             By: <a href={props.author_link}>{props.display_name}</a>
           </p>


### PR DESCRIPTION

## Summary

This PR fixes an issue where some `ArticleCard` components displayed broken image icons when rendering blog posts from the WordPress API.

The API can occasionally return an empty or invalid `jetpack_featured_media_url` for posts without a featured image (or when the referenced media no longer exists). Previously, the component attempted to render these URLs directly, resulting in broken image placeholders and a degraded user experience.

This change ensures that `ArticleCard` always displays a valid image by gracefully falling back to the default Podman logo whenever the provided image is unavailable.

---
## Issue closes: #525 


## Changes

- Added a fallback image when `jetpack_featured_media_url` is empty or undefined.
- Added an `onError` handler to the `<img>` element to handle failed image requests (e.g., deleted media or 404 responses).
- Uses `logos/optimized/podman-3-logo-266w-253h.webp` as the default fallback image.

---

## Why this change?

The frontend should not rely on external API data always being complete or valid. By handling missing and failed image loads gracefully, the UI becomes more resilient and provides a consistent visual experience regardless of the API response.

### Before
- Broken image icons were displayed when the API returned an invalid or missing image URL.
- Inconsistent appearance across blog cards.

### After
- Every `ArticleCard` displays a valid thumbnail.
- Missing or broken images automatically fall back to the default Podman logo.
- Consistent and polished user experience.

---

## Testing

Verified locally by testing the following scenarios:

- ✅ Valid featured image renders correctly.
- ✅ Empty `jetpack_featured_media_url` falls back to the default image.
- ✅ Invalid image URL (404) triggers the `onError` handler and displays the fallback image.
- ✅ Existing cards with valid images remain unaffected.

---

## Screenshots

### Before
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/7bc38d38-4112-4293-af2d-b4b193b4f87e" />


### After
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/8b3d3ef5-4176-4c9e-8c26-18263e17e660" />
---

## Checklist

- [x] Tested locally
- [x] Existing functionality remains unchanged
- [x] Follows the project's coding style
- [x] Handles missing and invalid image URLs gracefully
- [x] No breaking changes introduced