### PR TITLE
feat: modernize community meetings video grid UI

### DIFF
--- a/src/components/layout/CommunityMeetingsCardGrid/index.tsx
+++ b/src/components/layout/CommunityMeetingsCardGrid/index.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode, useEffect, useRef, useState } from 'react';
+import { Icon } from '@iconify/react';
 import CustomCard from '@site/src/components/ui/CustomCard';
 import SubcardGrid from '@site/src/components/layout/SubcardGrid';
 import SectionHeader from '@site/src/components/layout/SectionHeader';
@@ -45,6 +46,7 @@ type SubcardGridProps = {
   buttons: SubcardButtonProps[];
   icon: string;
   date: string;
+  thumbnailUrl?: string;
 };
 
 function toggleModalOpen(ref, handler) {
@@ -163,12 +165,20 @@ function CommunityMeetingsCardGrid({ cards }) {
   let communityMeetingsData: SubcardGridProps[] = [];
   let CabalMeetingsData: SubcardGridProps[] = [];
 
+  const parseYoutubeId = (url?: string) => {
+    if (!url) return null;
+    const match = url.match(/(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))([\w-]{11})/);
+    return match ? match[1] : null;
+  };
+
   // get top 2 CommunityMeetings & CabalMeetings for subcards
   for (let i = 0; i < 2; i++) {
     let meeting = MeetingDropdownOptions.shift();
+    let ytId1 = parseYoutubeId(meeting?.meeting_recording?.link);
     communityMeetingsData.push({
       date: meeting?.date,
       icon: 'film-icon',
+      thumbnailUrl: ytId1 ? `https://img.youtube.com/vi/${ytId1}/hqdefault.jpg` : undefined,
       buttons: [
         {
           path: meeting?.meeting_recording?.link,
@@ -178,9 +188,11 @@ function CommunityMeetingsCardGrid({ cards }) {
       ],
     });
     meeting = cabalDropdownOptions.shift();
+    let ytId2 = parseYoutubeId(meeting?.meeting_recording?.link);
     CabalMeetingsData.push({
       date: meeting?.date,
       icon: 'film-icon',
+      thumbnailUrl: ytId2 ? `https://img.youtube.com/vi/${ytId2}/hqdefault.jpg` : undefined,
       buttons: [
         {
           path: meeting?.meeting_recording?.link,
@@ -208,12 +220,12 @@ function CommunityMeetingsCardGrid({ cards }) {
               data={card?.buttons}
               primary={true}
             />
-            <SectionHeader
-              title=""
-              description="Most Recent meetings"
-              textGradientStops="from-purple-500 to-purple-700 dark:text-purple-500"
-              textGradient={false}
-            />
+            <div className="mt-8 mb-4 w-full px-2">
+              <h3 className="text-xl font-bold text-gray-100 flex items-center gap-2 border-l-4 border-purple-500 pl-3 m-0 py-1">
+                <Icon icon="fa-solid:video" className="text-purple-500" />
+                {index === 0 ? "Recent Community Meetings" : "Recent Cabal Meetings"}
+              </h3>
+            </div>
             <SubcardGrid key={`subcard-grid-${index}`} cards={meetingsData} toggleIsModalOpen={toggleIsModalOpen} />
             <Dropdown
               options={getDropdownOption(index == 1 ? [...cabalDropdownOptions] : [...MeetingDropdownOptions])}

--- a/src/components/layout/SubcardGrid/index.tsx
+++ b/src/components/layout/SubcardGrid/index.tsx
@@ -1,27 +1,90 @@
 import React from 'react';
-import CustomCard from '@site/src/components/ui/CustomCard';
+import { Icon } from '@iconify/react';
 import { DayOfTheWeek } from '@site/src/components/utilities/DateUtils';
+
+function MeetingVideoCard({ card, toggleIsModalOpen }) {
+  const dayIndex = new Date(card.date).getDay();
+  const dayName = DayOfTheWeek(dayIndex);
+  const videoLink = card.buttons?.[0]?.path;
+  const minutesData = card.buttons?.[1];
+
+  return (
+    <div className="group relative flex flex-1 flex-col overflow-hidden rounded-2xl border border-gray-700 bg-gray-800 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-purple-500 hover:shadow-2xl hover:shadow-purple-500/20">
+      {/* Video Thumbnail Header */}
+      <div 
+        className="relative aspect-video w-full cursor-pointer overflow-hidden bg-black"
+        onClick={() => videoLink && window.open(videoLink, '_blank')}
+      >
+        {card.thumbnailUrl ? (
+          <img 
+            src={card.thumbnailUrl} 
+            alt={card.date}
+            className="h-full w-full object-cover scale-[1.35] transition-transform duration-500 group-hover:scale-[1.42] opacity-90 group-hover:opacity-100"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gray-900">
+            <Icon icon="fa-solid:film" className="text-4xl text-gray-600" />
+          </div>
+        )}
+        
+        {/* Play Button Overlay */}
+        <div className="absolute inset-0 flex items-center justify-center bg-black/30 transition-all duration-300 group-hover:bg-black/10">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-purple-600/90 text-white shadow-xl transition-all duration-300 group-hover:scale-110 group-hover:bg-purple-500">
+            <Icon icon="fa-solid:play" className="translate-x-[2px] text-xl" />
+          </div>
+        </div>
+
+        {/* Floating Date Badge */}
+        <div className="absolute top-3 left-3 rounded-md bg-black/70 px-3 py-1 text-xs font-semibold text-white backdrop-blur-sm">
+          {card.date}
+        </div>
+      </div>
+
+      {/* Card Content Body */}
+      <div className="flex flex-1 flex-col justify-between p-4">
+        <div>
+          <div className="text-xs font-bold uppercase tracking-wider text-purple-400">
+            {dayName}
+          </div>
+          <h4 className="mt-1 text-lg font-bold text-gray-100">
+            Meeting Recording
+          </h4>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="mt-5 flex items-center gap-3">
+          <a
+            href={videoLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex flex-1 items-center justify-center gap-2 rounded-lg !bg-purple-600 px-4 py-2.5 text-sm font-bold !text-white !no-underline shadow-md transition-all hover:!bg-purple-500"
+          >
+            <Icon icon="fa-solid:play" className="text-xs" />
+            Watch
+          </a>
+          <button
+            onClick={() => toggleIsModalOpen(minutesData, card.date)}
+            className="flex flex-1 items-center justify-center gap-2 rounded-lg border border-gray-600 !bg-gray-700 px-4 py-2.5 text-sm font-bold !text-gray-100 transition-all hover:!bg-gray-600"
+          >
+            <Icon icon="fa-solid:file-alt" className="text-xs" />
+            Minutes
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function SubcardGrid({ cards, toggleIsModalOpen }) {
   return (
-    <div className="mb-4 flex lg:mb-6">
-      {cards?.map((card, index) => {
-        let date = new Date(card.date).getDay();
-        return (
-          <CustomCard
-            key={index}
-            title={card.date}
-            subtitle={DayOfTheWeek(date)}
-            details={card.timeZone}
-            text={card.subtitle}
-            data={card.buttons}
-            icon={card.icon}
-            method={meeting_minutes => {
-              toggleIsModalOpen(meeting_minutes, card.date);
-            }}
-          />
-        );
-      })}
+    <div className="my-4 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:gap-6 w-full px-1">
+      {cards?.map((card, index) => (
+        <MeetingVideoCard
+          key={index}
+          card={card}
+          toggleIsModalOpen={toggleIsModalOpen}
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/utilities/DropDown/index.tsx
+++ b/src/components/utilities/DropDown/index.tsx
@@ -35,11 +35,12 @@ function Dropdown(props: DropdownProps) {
       <div
         data-dropdown-toggle="dropdown"
         onClick={() => setIsOpen(prev => !prev)}
-        className="my-2 flex cursor-pointer items-center gap-1 py-2 pl-12 font-bold text-purple-700 dark:text-purple-500">
-        <div className={`transition duration-150 ease-linear ${isOpen && 'rotate-90'}`}>
-          <Icon icon="bi:caret-right-square-fill" />
-        </div>
+        className="my-4 mx-2 flex w-fit cursor-pointer items-center gap-2 rounded-xl border border-gray-600 bg-gray-800/50 px-5 py-2.5 text-sm font-semibold text-gray-200 shadow-sm backdrop-blur-sm transition-all duration-300 hover:border-purple-500 hover:bg-gray-800 hover:text-white"
+      >
         <span>{props.text}</span>
+        <div className={`transition-transform duration-300 ease-in-out ${isOpen ? 'rotate-90 text-purple-400' : 'text-gray-400'}`}>
+          <Icon icon="fa-solid:chevron-right" />
+        </div>
       </div>
       <div className="dropdown-options absolute mt-2 flex flex-col overflow-y-auto overflow-x-hidden shadow-md scrollbar-thin scrollbar-track-gray-100 scrollbar-thumb-gray-300 dark:bg-gray-900 md:max-h-full lg:max-h-96">
         {isOpen && props?.options.map(option => option)}


### PR DESCRIPTION

**Resolves:** #531 

---

## Summary

This PR modernizes the **"Most Recent Meetings"** section on the `/community` page by introducing a dedicated video card design, improving the overall layout, and fixing thumbnail loading issues for YouTube videos.

In addition to refreshing the UI, this change makes thumbnail generation more reliable, removes unnecessary nested card layouts, and improves the visual hierarchy and interactivity of the meetings section.

---

## What's Changed

### 🎥 Improved YouTube Thumbnail Handling

Updated the thumbnail generation logic in `CommunityMeetingsCardGrid/index.tsx` to make it more resilient.

**Changes include:**

- Improved the YouTube URL parser to support multiple URL formats, including:
  - `youtube.com/watch?v=...`
  - `youtu.be/...`
- Switched thumbnail generation from `maxresdefault.jpg` to `hqdefault.jpg`, preventing missing thumbnails for videos that do not provide maximum-resolution images.

---

### Introduced a Dedicated `MeetingVideoCard`

Created a new `MeetingVideoCard` component to replace the previous implementation that relied on the generic `CustomCard`.

The new component includes:

- Large 16:9 video thumbnail layout
- Responsive thumbnail presentation
- Thumbnail scaling to remove YouTube letterboxing
- Floating meeting date badge
- Glassmorphism overlay
- Animated play button
- Improved spacing and typography
- Cleaner component hierarchy without nested card borders

This results in a significantly more polished and media-focused presentation.

---

### UI & Styling Improvements

Refined the overall meetings section to provide a cleaner visual hierarchy and more consistent interactions.

**Improvements include:**

- Removed the "box-in-a-box" appearance caused by nested `CustomCard` components.
- Replaced duplicate **"Most Recent Meetings"** headings with distinct section titles:
  - **Recent Community Meetings**
  - **Recent Cabal Meetings**
- Redesigned the **"Older meeting details"** dropdown trigger as a modern pill-shaped button.
- Fixed button styling conflicts by overriding Docusaurus defaults with explicit Tailwind utility classes where required.
- Added smoother hover transitions and micro-interactions throughout the section.

---

## Why This Change?

These improvements address both functional and visual shortcomings in the existing implementation by:

- Ensuring YouTube thumbnails load reliably.
- Making meeting recordings immediately recognizable through visual previews.
- Eliminating unnecessary nested layouts.
- Improving responsiveness and accessibility.
- Creating a more engaging browsing experience that better aligns with the rest of the Podman website.

---

## Testing

Verified locally by testing the following scenarios:

- ✅ All supported YouTube URL formats generate thumbnails correctly.
- ✅ Videos without `maxresdefault` thumbnails display correctly using `hqdefault`.
- ✅ Meeting cards render without nested borders.
- ✅ Hover animations and play button overlays behave as expected.
- ✅ Dropdown styling is consistent in both light and dark themes.
- ✅ Responsive layout works across different viewport sizes.

---

## How to Test

1. Check out this branch locally.
2. Run:

   ```bash
   yarn start
   ```

3. Navigate to `/community`.
4. Scroll to the **Most Recent Meetings** section.
5. Verify that:
   - All meeting thumbnails load correctly.
   - The redesigned video cards render properly.
   - Hover animations and play button overlays work smoothly.
   - The dropdown button is styled correctly.
   - Section headings display as expected.
   - The layout remains responsive across different screen sizes.

---

## Screenshots

### Before

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/8c4def81-2d71-4186-93a7-a6a5bd2ace76" />

### After

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/6c1d1d8e-2919-4729-a97c-79ed405af52e" />