### PR TITLE
Fix header logo and toggle icon(☀️) visibility in light mode after browser resize 

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -66,6 +66,11 @@
   font-size: x-large;
 }
 
+.navbar-sidebar__brand .navbar__title,
+.navbar-sidebar__brand .clean-btn {
+  @apply text-gray-900 dark:text-gray-50;
+}
+
 .navbar__link svg,
 .footer__item svg {
   display: inline;


### PR DESCRIPTION
Fixes #549

This PR fixes an issue where the header text became difficult to see after resizing the browser window to a smaller desktop width and then switching from Dark mode to Light mode.

**Changes**
- Updated the header styles to ensure proper colors are applied in Light mode.
- Ensured the "Podman" text and other header elements remain clearly visible after resizing and changing the theme.

**Test**
- Tested in both Dark and Light themes.
- Verified behavior after resizing the browser window to smaller desktop widths.
- Confirmed that the header remains readable when switching between themes.
- Checked that the fix does not affect the default desktop layout.
<img width="1061" height="874" alt="Screenshot 2026-07-28 at 2 10 23 AM" src="https://github.com/user-attachments/assets/1d3287b1-bb1a-476d-a6c5-2d3b88149fd8" />



