### PR TITLE
fix docs sidebar contrast and logo overlap in light mode

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -59,11 +59,17 @@
   height: 7rem;
 }
 
-.navbar__title,
-.navbar__link,
-.clean-btn {
+.navbar__inner .navbar__title,
+.navbar__inner .navbar__link,
+.navbar__inner .clean-btn {
   @apply text-white dark:text-gray-50;
   font-size: x-large;
+}
+
+.navbar-sidebar__back {
+  @apply text-gray-900 dark:text-gray-50;
+  font-size: x-large;
+  margin-top: 1rem;
 }
 
 .navbar__link svg,


### PR DESCRIPTION
Fixes #562

This PR fixes multiple UI issues that occurred on the documentation pages after resizing the browser window in Light Mode.

**Changes**
Fixed the visibility of the "Back to main menu" text in Light Mode.
Fixed the menu background overlapping the Podman logo.
Improved the visibility of the "On this page" text after the responsive layout is triggered.

**Testing**
☑️ Verified the fixes on documentation pages.
☑️ Tested by resizing the browser window to smaller desktop widths.
☑️ Confirmed that all affected elements remain readable and properly aligned in Light Mode