### PR TITLE
fix(a11y): add alt text to images missing it

### DIFF
--- a/src/components/ui/ArticleCard/index.tsx
+++ b/src/components/ui/ArticleCard/index.tsx
@@ -50,6 +50,7 @@ function ArticleCard(props: ArticleCardProps) {
             </div>
             <img
               src={props.imgSrc}
+              alt={props.title}
               className=" col-start-1 row-start-1 h-full w-full rounded-sm object-cover lg:w-80"
             />
           </div>
@@ -78,7 +79,7 @@ function ArticleCard(props: ArticleCardProps) {
           </h3>
           {parse(abbrSubtitle)}
           <PublishDate date={props.date} styles="row-start-1 col-start-1 z-10 my-2" />
-          <img src={props.imgSrc} className="object-fit col-start-1 row-start-1 rounded-sm" />
+          <img src={props.imgSrc} alt={props.title} className="object-fit col-start-1 row-start-1 rounded-sm" />
           <p className="text-purple-700">
             By: <a href={props.author_link}>{props.display_name}</a>
           </p>

--- a/src/pages/features.tsx
+++ b/src/pages/features.tsx
@@ -47,7 +47,7 @@ const PodmanDesktopSection = () => {
       </div>
       <div className="container flex flex-col md:flex-row items-center">
         <div id="imgdiv" className="mx-auto w-full md:w-auto">
-          <img id="pdlogo" className="mx-auto" src="logos/optimized/podman-desktop-logo-200w-198h.webp" />
+          <img id="pdlogo" className="mx-auto" src="logos/optimized/podman-desktop-logo-200w-198h.webp" alt="Podman Desktop logo" />
         </div>
         <div className="md:w-1/2 xl:w-3/4">
           <p className="my-8 align-middle text-2xl leading-relaxed">
@@ -158,7 +158,7 @@ const PodmanCLISection = () => {
       </div>
       <div className="container mb-4 grid gap-2 lg:grid-cols-3">
         <div className="mx-auto">
-          <img className="max-h-[200px]" src="images/optimized/podman-selkie-385w-358h.webp" />
+          <img className="max-h-[200px]" src="images/optimized/podman-selkie-385w-358h.webp" alt="Podman Selkie mascot" />
         </div>
         <div className="col-span-2">
           <p className="my-8 align-middle text-2xl leading-relaxed">


### PR DESCRIPTION
## What this PR does

Adds `alt` text to the `<img>` elements that were missing it, fixing a WCAG 2.1 1.1.1 (Non-text Content) accessibility gap:

- `ArticleCard` (both the featured and normal layouts): uses `alt={props.title}`, so the thumbnail is described by its article title.
- `features.tsx`: the Podman Desktop logo (`alt="Podman Desktop logo"`) and the Selkie mascot (`alt="Podman Selkie mascot"`).

Other images in the codebase already pass an `alt`, so these were oversights.

Fixes #574

## Testing

`yarn build` succeeds and generates `build/index.html` (matching CI). Change is additive (`alt` attributes only).
