### PR TITLE
fix: add key prop to mapped meeting dropdown options

### DIFF
--- a/src/components/layout/CommunityMeetingsCardGrid/index.tsx
+++ b/src/components/layout/CommunityMeetingsCardGrid/index.tsx
@@ -155,7 +155,7 @@ function CommunityMeetingsCardGrid({ cards }) {
   }
 
   function getDropdownOption(options: DropdownOptionProps[]) {
-    return options.map(option => <DropDownOption {...option} />);
+    return options.map((option, index) => <DropDownOption key={index} {...option} />);
   }
 
   populateMeetings();


### PR DESCRIPTION
## What this PR does

`getDropdownOption` in `CommunityMeetingsCardGrid` rendered a list of `DropDownOption` elements from `.map()` without a `key`, which triggers React's *"Each child in a list should have a unique key prop"* warning and makes reconciliation fall back to index matching. Adds a `key` to each mapped element.

Fixes #575

## Testing

`yarn build` succeeds and generates `build/index.html` (matching CI).
