### PR TITLE
Fix/issue 581 carousel consistency

### DIFF
--- a/src/components/content/FeaturesCarousel/index.tsx
+++ b/src/components/content/FeaturesCarousel/index.tsx
@@ -30,8 +30,8 @@ const TabContent = (props): JSX.Element => {
   const { title, commands, image, description, isActive } = props;
   return (
     <>
-      <div className="xl:my-23 container my-12 flex flex-wrap justify-center gap-4 md:gap-12">
-        <div className="max-w-sm">
+      <div className="xl:my-23 container my-12 flex flex-wrap items-center justify-center gap-4 md:gap-12">
+        <div className="flex min-h-[23rem] max-w-sm flex-col justify-center">
           <h3
             className={`text-3xl ${
               isActive % 2 === 0
@@ -53,8 +53,8 @@ const TabContent = (props): JSX.Element => {
             {description}
           </p>
         </div>
-        <div className={`${isActive % 2 === 1 && 'md:order-first'}`}>
-          <img {...image} className="object-fit lg:w-[600px]" />
+        <div className={`flex w-full max-w-[600px] justify-center ${isActive % 2 === 1 && 'md:order-first'}`}>
+          <img {...image} className="h-64 w-full rounded-lg object-cover shadow-lg md:h-72 lg:h-80" />
         </div>
       </div>
     </>
@@ -83,7 +83,7 @@ function FeaturesCarousel() {
             ? 'bg-gradient-to-br from-blue-300 via-blue-500 to-blue-900 dark:from-blue-900 dark:to-gray-700/50'
             : 'bg-gradient-to-br from-purple-300 via-purple-700 to-purple-900'
         }`}>
-        <div className="space-between container flex">
+        <div className="space-between container flex items-center">
           <button
             type="button"
             onClick={() => setActiveTabIndex(activeTabIndex > 0 ? activeTabIndex - 1 : tabData.length - 1)}

--- a/src/components/utilities/PlayOnScroll/index.tsx
+++ b/src/components/utilities/PlayOnScroll/index.tsx
@@ -15,10 +15,12 @@ const PlayOnScroll: React.FC = (props: VideoProps) => {
         if (videoRef.current) {
           const rect = videoRef.current.getBoundingClientRect();
           const isFullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
-          
+
           if (isFullyVisible) {
-            videoRef.current.play();
-          } else {
+            if (videoRef.current.paused) {
+              videoRef.current.play().catch(() => {});
+            }
+          } else if (!videoRef.current.paused) {
             videoRef.current.pause();
           }
         }


### PR DESCRIPTION
Fixes #581

The Find/Run/Build/Share cards on the features page use plain <img> tags with no fixed height, so each card's height followed its own screenshot's aspect ratio. The "Find" screenshot happens to have a different aspect ratio than the other three, so switching tabs (and resizing the window around the point where the layout wraps) made the whole row grow or shrink, and the left/right arrow buttons jumped up and down with it.

- Gave the image a fixed height per breakpoint with object-cover so all four tabs render the same size box regardless of the source image's aspect ratio
- Gave the text column a matching min-height so a shorter description doesn't shrink the row below the tallest one
- Centered both columns with items-center so the arrows stay put

While testing this on the features page I also ran into an unrelated bug: scrolling the page spams videoRef.current.play() on every scroll event in PlayOnScroll, even when the video is already playing, and the rejected promise from repeated play() calls was uncaught - it was throwing a wall of "Uncaught runtime errors" in the dev console on every scroll tick. Fixed that too since it made testing the actual carousel change pretty hard to see through the error overlay.

## Test plan
- [ ] Go to /features, click through Find/Run/Build/Share and confirm the arrows don't move vertically
- [ ] Resize the browser window (including widths where the layout wraps to stacked) and confirm no jump
- [ ] Scroll up/down through the video sections further down the page and confirm no error overlay appears, and videos still play/pause on scroll into/out of view


https://github.com/user-attachments/assets/fc13c6f6-5902-495f-b9b4-4fe4d4255718



