### PR TITLE
fix: add error state handling for API calls on core pages

### DIFF
--- a/src/pages/features.tsx
+++ b/src/pages/features.tsx
@@ -173,6 +173,7 @@ const PodmanCLISection = () => {
 /* TODO Should be componentized at some point */
 const LearnArticles = () => {
   const [blogData, setBlogData] = useState([]);
+  const [hasError, setHasError] = useState(false);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -182,7 +183,10 @@ const LearnArticles = () => {
       const jsonData = await rawData.json();
       setBlogData(jsonData);
     };
-    fetchData().catch(console.error);
+    fetchData().catch((err) => {
+      console.error(err);
+      setHasError(true);
+    });
   }, []);
   return (
     <section className="my-4 lg:my-0">
@@ -190,7 +194,10 @@ const LearnArticles = () => {
         <h3 className="font-medium text-blue-700 dark:text-blue-500">{learnMore.blogPosts.title}</h3>
       </header>
       <div className="flex flex-col gap-4">
-        {blogData.map((card, index) => {
+        {hasError ? (
+          <p className="ml-2 text-center text-gray-500 2xl:text-start">Failed to load latest blog posts.</p>
+        ) : (
+          blogData.map((card, index) => {
           if (index < 2) {
             return (
               <ArticleCard
@@ -206,7 +213,8 @@ const LearnArticles = () => {
               />
             );
           }
-        })}
+        })
+        )}
         <p className="ml-2l text-center 2xl:text-start">
           Check out more posts about Podman{' '}
           <a

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -49,6 +49,7 @@ const CompatibleToolSection = () => {
 
 const LatestNews = () => {
   const [blogData, setBlogData] = useState([]);
+  const [hasError, setHasError] = useState(false);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -58,13 +59,19 @@ const LatestNews = () => {
       const jsonData = await rawData.json();
       setBlogData(jsonData);
     };
-    fetchData().catch(console.error);
+    fetchData().catch((err) => {
+      console.error(err);
+      setHasError(true);
+    });
   }, []);
   return (
     <section>
       <SectionHeader title="Latest Podman News" textColor="text-purple-700" />
       <div className="flex flex-wrap justify-center gap-4">
-        {blogData.map(card => {
+        {hasError ? (
+          <p className="text-gray-500 my-8">Failed to load latest Podman news. Please check your connection.</p>
+        ) : (
+          blogData.map(card => {
           return (
             <ArticleCard
               title={card.title.rendered}
@@ -77,7 +84,8 @@ const LatestNews = () => {
               key={card.id}
             />
           );
-        })}
+        })
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

This PR adds graceful error handling to the client-side API fetch logic on the homepage and features page. If the GitHub API request fails (due to rate limits, network issues, etc.), the UI now displays a user-friendly fallback message instead of silently failing or rendering broken data.

## What Changed

### 1. Introduced Error State Variables

Added `hasError` state to track failed API requests in:
- `src/pages/index.tsx`
- `src/pages/features.tsx`

```tsx
const [hasError, setHasError] = useState(false);
```

### 2. Updated Error Handling in Catch Blocks

Modified the `.catch()` handlers to set the error state when a fetch fails:

```tsx
// Before
fetchData().catch(console.error);

// After
fetchData().catch((err) => {
  console.error(err);
  setHasError(true); // Notify React that the fetch failed
});
```

### 3. Added Graceful Fallback UI

Updated the React rendering logic to show a user-friendly message when `hasError` is true, instead of rendering empty or undefined data:

**Homepage (`index.tsx`):**
- Shows: `"Failed to load latest Podman news. Please check your connection."`

**Features Page (`features.tsx`):**
- Shows: `"Failed to load latest blog posts."`

## Why This Matters

Before this change, if the GitHub API request failed, users would experience:
- A perpetual loading state
- Empty or broken data fields
- No indication of what went wrong

After this change, users see a clear, contextual error message and the rest of the page remains functional.

After Screenshots -->
 
| <img width="1438" height="780" alt="learn ore section after api fail" src="https://github.com/user-attachments/assets/3dcc7bb1-f848-4f9c-a71f-07e7624f4078" />| <img width="1440" height="780" alt="If API fails then latest features page" src="https://github.com/user-attachments/assets/6fd385d5-d87d-4f98-92d8-72c2cce996b0" />| 
|--------|-----|

## Testing

- [x] Verified changes compile cleanly within Docusaurus build
- [x] Test both pages with API fetch deliberately failing (network throttling, offline mode)
- [x] Confirm fallback UI displays correctly when error state is true
- [x] Confirm normal UI displays when fetch succeeds
- [x] Verify no console errors introduced

## Related Issue

Closes #595 