### PR TITLE
fix: add missing path prop to PR submission button

### DIFF
--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -187,7 +187,7 @@ const PullRequestSection = () => {
             return <li key={index}>{item}</li>;
           })}
         </ul>
-        <Button as="link" outline={true} text={submittingIssues[2].button.text} />
+        <Button as="link" outline={true} text={submittingIssues[2].button.text} path={submittingIssues[2].button.path} />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary

This PR fixes a broken button on the `/community` page. The "More PR Submission Details" button appeared interactive (with hover effects) but was non-functional because it was missing the required `path` prop.

## What Changed

### Fixed Missing Prop in Button Component

**File:** `src/pages/community.tsx` (line 190)

**Before:**
```tsx
<Button as="link" outline={true} text={submittingIssues[2].button.text} />
```

**After:**
```tsx
<Button as="link" outline={true} text={submittingIssues[2].button.text} path={submittingIssues[2].button.path} />
```

## Why This Matters

The button now correctly links to the Podman CONTRIBUTING.md file's "Submitting Pull Requests" section (`https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests`), which is already defined in the data object but was never being passed to the component.

Users can now click the button and be taken to the intended documentation page.

## Testing

- [x] Verified `submittingIssues[2].button.path` contains the correct URL
- [x] Tested clicking the button on the Community page — confirms navigation to the correct URL

## Related Issue

Closes #597 