### PR TITLE
fix: improve Community Links icon styling and consistent hover effects

### DIFF
--- a/src/components/utilities/IconLink/index.tsx
+++ b/src/components/utilities/IconLink/index.tsx
@@ -21,7 +21,7 @@ function IconLink({ text, path, icon, image, textLogo }: IconLinkProps) {
           <img src={image.path} alt={image.alt} className="w-16" />
         )}
       </div>
-      <span className="underline-offset-6 mt-4 block text-blue-700 underline transition-colors duration-200 ease-out group-hover:text-purple-700 dark:text-blue-300 dark:group-hover:text-purple-300">
+      <span className="mt-4 block text-blue-700 no-underline transition-colors duration-200 ease-out group-hover:text-purple-700 dark:text-blue-300 dark:group-hover:text-purple-300">
         {text}
       </span>
     </a>

--- a/src/components/utilities/IconLink/index.tsx
+++ b/src/components/utilities/IconLink/index.tsx
@@ -9,17 +9,19 @@ export type IconLinkProps = Link & {
 
 function IconLink({ text, path, icon, image, textLogo }: IconLinkProps) {
   return (
-    <a href={path} className="mx-auto flex flex-col items-center text-center">
-      <div className="max-w-fit rounded-full bg-white p-8 shadow-sm  dark:bg-gray-900">
+    <a
+      href={path}
+      className="group mx-auto flex flex-col items-center text-center no-underline transition-transform duration-200 ease-out hover:-translate-y-1 hover:no-underline">
+      <div className="flex h-24 w-24 items-center justify-center rounded-full bg-white text-gray-900 shadow-sm ring-2 ring-transparent transition-all duration-200 ease-out group-hover:bg-purple-50 group-hover:text-purple-700 group-hover:shadow-lg group-hover:shadow-purple-500/30 group-hover:ring-purple-300 dark:bg-gray-700 dark:text-white dark:ring-1 dark:ring-white/10 dark:group-hover:bg-purple-700 dark:group-hover:text-white dark:group-hover:shadow-lg dark:group-hover:shadow-purple-500/40 dark:group-hover:ring-purple-300">
         {icon ? (
           <Icon icon={icon} className="text-5xl" />
         ) : textLogo ? (
-          <span className="block py-2 font-display text-4xl font-extrabold">{textLogo}</span>
+          <span className="block font-display text-4xl font-extrabold">{textLogo}</span>
         ) : (
           <img src={image.path} alt={image.alt} className="w-16" />
         )}
       </div>
-      <span className="underline-offset-6 duration-149 mt-4 block text-blue-700 underline transition ease-linear hover:text-blue-900">
+      <span className="underline-offset-6 mt-4 block text-blue-700 underline transition-colors duration-200 ease-out group-hover:text-purple-700 dark:text-blue-300 dark:group-hover:text-purple-300">
         {text}
       </span>
     </a>

--- a/static/data/community.ts
+++ b/static/data/community.ts
@@ -17,7 +17,7 @@ const communityChat = {
     'The Podman developers are generally around during CEST and Eastern Time business hours, so please be patient if you’re in another time zone!',
   links: [
     {
-      text: '#podman:matrix.org',
+      text: 'Matrix',
       path: 'https://matrix.to/#/#podman:fedoraproject.org',
       image: {
         path: 'logos/optimized/element-56w-59h.webp',
@@ -25,17 +25,17 @@ const communityChat = {
       },
     },
     {
-      text: '#podman on libera.chat',
+      text: 'IRC',
       path: 'https://web.libera.chat/#podman-desktop',
       textLogo: 'IRC',
     },
     {
-      text: 'Podman GitHub Discussions',
+      text: 'GitHub',
       path: 'https://github.com/containers/podman/discussions',
       icon: 'fa6-brands:github',
     },
     {
-      text: 'Podman Discord',
+      text: 'Discord',
       path: 'https://discord.gg/vwpj7K6gW5',
       icon: 'logos:discord-icon',
     },

--- a/static/data/community.ts
+++ b/static/data/community.ts
@@ -32,10 +32,7 @@ const communityChat = {
     {
       text: 'Podman GitHub Discussions',
       path: 'https://github.com/containers/podman/discussions',
-      image: {
-        path: 'vectors/raw/github.svg',
-        alt: 'GitHub Logo',
-      },
+      icon: 'fa6-brands:github',
     },
     {
       text: 'Podman Discord',


### PR DESCRIPTION
_Fixes #589 — the Community Links icons (Matrix, IRC, GitHub, Discord) were inconsistent across themes and only the IRC icon had a visible hover effect.

**What Changes**
- Replaced the hardcoded black GitHub SVG with the fa6-brands:github Iconify icon so it follows currentColor and remains visible in both light and dark mode.
- Made all Community Links icons (Matrix, IRC, GitHub, and Discord) the same size by using a fixed circular container instead of max-w-fit.
- Updated the dark mode background for the icon circles to improve contrast with the section background.
- Applied the same hover effect to all icons, including the lift animation, purple ring/glow, and label color change, for a more consistent experience.
- Shortened the labels to just the platform names (Matrix, IRC, GitHub, Discord) and removed the underline to give the section a cleaner look.

**Test plan**
- Verified the changes locally in Chromium using Playwright.
- Tested in both light and dark mode.
- Confirmed all four icons have the same hover behavior and consistent sizing.
- Verified the GitHub icon is clearly visible in dark mode.
- Ran tsc --noEmit; the only reported error is the existing unrelated one in get-started.tsx.

<img width="1219" height="254" alt="Screenshot 2026-07-30 at 6 28 38 PM" src="https://github.com/user-attachments/assets/8b38941a-3577-4050-b235-c2ae27c0bcab" />

<img width="1213" height="234" alt="Screenshot 2026-07-30 at 6 28 49 PM" src="https://github.com/user-attachments/assets/c61d5a43-03e3-4976-97c3-e88f8e6557f5" />
