### PR TITLE
fix: stack community meeting cards on smaller desktop widths

### DIFF
--- a/src/components/layout/CommunityMeetingsCardGrid/index.tsx
+++ b/src/components/layout/CommunityMeetingsCardGrid/index.tsx
@@ -192,13 +192,13 @@ function CommunityMeetingsCardGrid({ cards }) {
   }
 
   return (
-    <div className="justify-content-center align-items-center custom-card-grid-root flex">
+    <div className="justify-content-center align-items-center custom-card-grid-root flex flex-wrap">
       {cards.map((card: CommunityMeetingsCardProps, index: number) => {
         let meetingsData = index == 1 ? CabalMeetingsData : communityMeetingsData;
         return (
           <div
             key={`card-container-${index}`}
-            className="align-items-center card-container mb-4 flex flex-1 flex-col flex-wrap justify-center transition duration-150 ease-linear lg:mb-6">
+            className="align-items-center card-container mb-4 flex min-w-[35rem] flex-1 flex-col flex-wrap justify-center transition duration-150 ease-linear lg:mb-6">
             <CustomCard
               key={`custom-card-${index}`}
               title={card?.title}

--- a/src/components/ui/CustomCard/index.tsx
+++ b/src/components/ui/CustomCard/index.tsx
@@ -78,8 +78,8 @@ function CardInfoButtons(cardInfoButtonProps: CardInfoButtonProps) {
 function CustomCard(props) {
   return (
     <article
-      style={props.primary ? { maxHeight: '550px', flex: 1 } : {}}
-      className="flex w-11/12 flex-col rounded-lg bg-gray-50 p-4 shadow-xl dark:bg-gray-700 dark:shadow-none lg:mx-8 lg:my-4">
+      style={props.primary ? { maxHeight: '550px' } : {}}
+      className="mx-2 my-2 flex flex-1 min-w-[15rem] flex-col rounded-lg bg-gray-50 p-4 shadow-xl dark:bg-gray-700 dark:shadow-none lg:mx-8 lg:my-4">
       <CardHeader {...props} />
       {props?.icon ? <FilmIcon /> : <CardBody {...props} />}
       <CardInfoButtons {...props} />


### PR DESCRIPTION
fix #591 


This PR improves the responsiveness of the Community Meetings section on smaller desktop window sizes.

Previously, when the browser window was narrowed, the meeting cards remained in a single horizontal row, forcing users to scroll horizontally to view the remaining cards.

**Changes**
Updated the layout so the Community Meetings cards wrap onto the next row when there isn't enough horizontal space.
Removed the need for horizontal scrolling on smaller desktop widths.
Improved readability and overall browsing experience while keeping the existing design intact.


https://github.com/user-attachments/assets/46ce7135-6e70-4c15-aa1b-65c12d6c434b

