### PR TITLE
ci: add PR quota limit workflow for new contributors

### DIFF
--- a/.github/workflows/pr_quota_limit.yml
+++ b/.github/workflows/pr_quota_limit.yml
@@ -1,0 +1,114 @@
+name: PR Quota Limit
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-pr-quota:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Check PR quota
+        # Use action version v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            try {
+              const prAuthor = context.payload.pull_request.user.login;
+              const authorAssociation = context.payload.pull_request.author_association;
+              const currentPRNumber = context.payload.pull_request.number;
+
+              console.log(`Checking PR quota for user: ${prAuthor} (${authorAssociation})`);
+              console.log(`Current PR number: ${currentPRNumber}`);
+
+              // Only enforce the quota on new contributors, not established ones
+              const newContributorAssociations = ['FIRST_TIME_CONTRIBUTOR', 'FIRST_TIMER', 'NONE'];
+              if (!newContributorAssociations.includes(authorAssociation)) {
+                console.log(`Author association "${authorAssociation}" is not a new contributor, skipping quota check.`);
+                return;
+              }
+
+              // Get all open PRs with pagination support
+              let allPRs = [];
+              let page = 1;
+              let hasMorePages = true;
+
+              while (hasMorePages) {
+                const { data: prs } = await github.rest.pulls.list({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'open',
+                  per_page: 100,
+                  page: page
+                });
+
+                allPRs = allPRs.concat(prs);
+
+                // If we got less than 100 PRs, we've reached the last page
+                if (prs.length < 100) {
+                  hasMorePages = false;
+                } else {
+                  page++;
+                }
+              }
+
+              console.log(`Total open PRs in repository: ${allPRs.length}`);
+
+              // Filter PRs by the same author
+              const userPRs = allPRs.filter(pr => pr.user.login === prAuthor);
+              const openCount = userPRs.length;
+
+              console.log(`User ${prAuthor} has ${openCount} open PR(s)`);
+
+              // Check if exceeds quota (2 PRs max for new contributors)
+              const maxPRs = 2;
+              if (openCount > maxPRs) {
+                const currentStatus = `${openCount}/${maxPRs}`;
+
+                const message = `Hi, @${prAuthor}, Thanks for your contribution! To ensure quality reviews, we limit how many concurrent open PRs new contributors can have (Current status: ${currentStatus} open). This pull request will be temporarily closed. We encourage you to submit a new PR once one of your existing PRs has been reviewed.`;
+
+                console.log(`Quota exceeded! Closing PR #${currentPRNumber}`);
+                console.log(`User has ${openCount} open PRs, which exceeds the limit of ${maxPRs}`);
+                console.log(`Message: ${message}`);
+
+                // Add comment to the PR
+                try {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: currentPRNumber,
+                    body: message
+                  });
+                  console.log('Comment added successfully');
+                } catch (commentError) {
+                  console.error('Failed to add comment:', commentError.message);
+                }
+
+                // Close the PR
+                try {
+                  await github.rest.pulls.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: currentPRNumber,
+                    state: 'closed'
+                  });
+                  console.log(`PR #${currentPRNumber} has been closed due to quota limit.`);
+                } catch (closeError) {
+                  console.error('Failed to close PR:', closeError.message);
+                  throw closeError; // Re-throw to fail the workflow
+                }
+              } else {
+                const availableSlots = maxPRs - openCount;
+                console.log(`Quota check passed. User has ${availableSlots} slot(s) available.`);
+              }
+            } catch (error) {
+              console.error('Error in PR quota check:', error.message);
+              throw error; // Re-throw to fail the workflow
+            }


### PR DESCRIPTION

This PR adds a GitHub Action that automatically enforces the project's policy of allowing a maximum of two open pull requests per new contributor.

**What this does**
-Checks the number of open PRs for a contributor when a new PR is opened.
-Allows up to 2 open PRs per new contributor.
-Automatically closes any additional PRs beyond the limit.
-Posts a friendly comment explaining why the PR was closed and asks the contributor to submit it again after one of their existing PRs has been merged.

**Benefits**
- Enforces the contribution policy automatically.
- Reduces manual work for maintainers.
- Keeps the review queue organized.
- Encourages contributors to focus on existing PRs before opening new ones.