### PR TITLE
fix(ui): show contributor cards in light mode

### DIFF
--- a/src/components/content/ThankYouSection/index.tsx
+++ b/src/components/content/ThankYouSection/index.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import sponsorData from './data';
 import { Icon } from '@iconify/react';
 
+const contributorCardClass =
+  'mx-4 mb-4 inline-block rounded-md bg-gray-100 p-4';
+
 function ThankYouSection(): JSX.Element {
   const [redHat, amadeus, suse, motorola, ntt, ibm, debian] = sponsorData;
   const slideLeft = () => {
@@ -33,43 +36,43 @@ function ThankYouSection(): JSX.Element {
           <a
             href={redHat.href}
             target="_blank"
-            className="mx-4 mb-4 inline-block rounded-md p-4  dark:bg-gray-100 lg:row-span-2 lg:row-start-1 lg:mb-0">
+            className={`${contributorCardClass} lg:row-span-2 lg:row-start-1 lg:mb-0`}>
             <img {...redHat} className="mx-auto p-4" />
           </a>
           <a
             href={amadeus.href}
             target="_blank"
-            className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
+            className={`${contributorCardClass} lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center`}>
             <img {...amadeus} className="object-fit mx-auto max-w-sm p-4 " />
           </a>
           <a
             href={suse.href}
             target="_blank"
-            className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
+            className={`${contributorCardClass} lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center`}>
             <img {...suse} className="object-fit mx-auto max-w-sm p-4 " />
           </a>
           <a
             href={motorola.href}
             target="_blank"
-            className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:row-span-2 lg:row-start-1 lg:mb-0">
+            className={`${contributorCardClass} lg:row-span-2 lg:row-start-1 lg:mb-0`}>
             <img {...motorola} className="mx-auto p-4" />
           </a>
           <a
             href={ntt.href}
             target="_blank"
-            className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
+            className={`${contributorCardClass} lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center`}>
             <img {...ntt} className="object-fit mx-auto max-w-sm p-4 " />
           </a>
           <a
             href={ibm.href}
             target="_blank"
-            className="col-span-3 mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
+            className={`col-span-3 ${contributorCardClass} lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center`}>
             <img {...ibm} className="object-fit mx-auto max-w-sm p-4 " />
           </a>
           <a
             href={debian.href}
             target="_blank"
-            className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:row-span-2 lg:row-start-1 lg:mb-0">
+            className={`${contributorCardClass} lg:row-span-2 lg:row-start-1 lg:mb-0`}>
             <img {...debian} className="mx-auto p-4" />
           </a>
         </div>


### PR DESCRIPTION
This PR fixes #588 

Added a visible background to contributor cards in light mode. Now contributor cards are clearly visible and consistent in light mode.

<img width="1722" height="955" alt="image" src="https://github.com/user-attachments/assets/53b98ccb-c41d-482b-97f1-e19099b85c16" />