### PR TITLE
fix(ui): remove horizontal overflow on community page

### DIFF
--- a/src/components/layout/PageHeader/index.tsx
+++ b/src/components/layout/PageHeader/index.tsx
@@ -92,7 +92,7 @@ function PageHeader({ title, description, image, lightColor = 'white', darkColor
           <TextBox title={title} description={description} layout="mt-12 lg:mt-0 mb-8" />
           <Instructions instructions={instructions} />
         </div>
-        <div className="w-[50%] ml-24">
+        <div className="w-full md:w-1/2 md:ml-12 lg:ml-24">
           <PageHeaderSupplementalInfo basicResources={basicResources} />
         </div>
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -6,6 +6,12 @@
 @import 'fonts/source-sans-pro.css';
 @import 'fonts/source-code-pro.css';
 
+html,
+body {
+  overflow-x: hidden;
+  max-width: 100%;
+}
+
 :root {
   --ifm-color-primary: #892ca0;
   --ifm-color-primary-darkest: #5f246b;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

For more detailed information, please review our contributing guidelines:
https://github.com/podman-container-tools/community/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->
#### Concisely describe the change
Fixed horizontal page scrolling on the `/community` route caused by an un-responsive margin pushing header elements past the viewport width.
Replaced the fixed margin with responsive breakpoint classes and added `overflow-x: hidden` to global body styles.

#### Before screenshot / screen recording
<img width="1915" height="597" alt="image" src="https://github.com/user-attachments/assets/ed44e1c9-84c9-4f07-a8b6-12acc9d391ee" />

#### After screenshot / screen recording
<img width="1918" height="957" alt="image" src="https://github.com/user-attachments/assets/8bc41464-b49c-4686-9101-b121b54a1e09" />

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
