### PR TITLE
fix: add missing path prop to PR submission button

### DIFF
--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -187,7 +187,7 @@ const PullRequestSection = () => {
             return <li key={index}>{item}</li>;
           })}
         </ul>
-        <Button as="link" outline={true} text={submittingIssues[2].button.text} />
+        <Button as="link" outline={true} text={submittingIssues[2].button.text} path={submittingIssues[2].button.path} />
       </div>
     </section>
   );


### PR DESCRIPTION
<!--
Thanks for sending a pull request!
For more detailed information, please review our contributing guidelines:
https://github.com/podman-container-tools/community/blob/main/CONTRIBUTING.md#submitting-pull-requests
-->

#### Concisely describe the change

Fixes a broken "More PR Submission Details" button on the `/community` page. The button appeared interactive (with hover effects) but was non-functional because it was missing the required `path` prop.

**File:** `src/pages/community.tsx` (line 190)

**Before:**
```tsx
<Button as="link" outline={true} text={submittingIssues[2].button.text} />
```

**After:**
```tsx
<Button as="link" outline={true} text={submittingIssues[2].button.text} path={submittingIssues[2].button.path} />
```

The button now correctly links to Podman's `CONTRIBUTING.md` "Submitting Pull Requests" section (https://github.com/containers/podman/blob/main/CONTRIBUTING.md#submitting-pull-requests), which was already defined in the data object but never passed to the component.

Closes #597

#### Checklist


- [x] DCO Signed off

- [x] PR description, commit message, and GitHub comments are human-written, as per LLM Policy