### PR TITLE
fix: resolve coloring book section layout on small viewports

### DIFF
--- a/src/components/content/ColoringBookSection/index.tsx
+++ b/src/components/content/ColoringBookSection/index.tsx
@@ -5,7 +5,7 @@ function ColoringBookSection() {
   return (
     <section className="container my-12 flex flex-wrap justify-center gap-4 lg:justify-start xl:my-20">
       <div className="flex">
-        <div className="mx-4 flex-col items-center text-center lg:mx-0 lg:items-start lg:text-start">
+        <div className="mx-4 flex flex-col items-center text-center lg:mx-0 lg:items-start lg:text-start">
           <h2 className="my-4 p-0 font-medium text-blue-900 dark:text-blue-500">{data.title}</h2>
           <p className="mb-4 max-w-prose lg:mb-10">{data.description}</p>
           <Button
@@ -15,11 +15,11 @@ function ColoringBookSection() {
             colors="hover:bg-purple-700 dark:hover:bg-purple-900 dark:bg-purple-500 dark:text-purple-700 hover:text-white outline"
           />
         </div>
-        <div className="order-first mr-12 hidden lg:block">
+        <div className="order-first mb-8 lg:mr-12 lg:mb-0">
           <img src={data.featureImage.src} alt={data.featureImage.alt} />
         </div>
       </div>
-      <div className="order-first mx-auto lg:order-last xl:mx-0">
+      <div className="order-last mx-auto mt-8 xl:mx-0 lg:mt-0">
         <img src={data.collageImages.src} alt={data.collageImages.alt} />
       </div>
     </section>


### PR DESCRIPTION
#### Concisely describe the change

This PR fixes a responsive layout bug where the Coloring Book section would break and disappear on viewports smaller than `lg`. 

The issue was caused by conflicting Tailwind utility classes:
- The cover image had a `hidden lg:block` class causing it to vanish completely on small screens.
- The flex layout lacked the base `flex` class.
- The flex ordering pushed the collage above the text on small screens.

This update removes the `hidden` attribute, applies the correct base flex class, adjusts the `order` logic for a clean vertical stack on mobile, and adds proper margins to prevent overlapping.

Fixes #557

<img width="592" height="703" alt="image" src="https://github.com/user-attachments/assets/e71a6c0e-52ac-4be2-8db2-2f469758015e" />

*N/A - See Issue #557 for original bug recording.*

<img width="538" height="794" alt="image" src="https://github.com/user-attachments/assets/ee689575-af15-471b-b739-af93964c9e8f" />


#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. ('git commit -s').
- [x] Referenced issues using 'Fixes: #00000' in commit message (if applicable)
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy]