### PR TITLE
docs: add catatonit installation step for EL9

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -361,8 +361,8 @@ sudo dnf -y builddep rpm/podman.spec --enablerepo=crb
 # RHEL 9+
 sudo dnf -y builddep rpm/podman.spec --enablerepo=codeready-builder-for-rhel-$(rpm --eval %{?rhel})-$(uname -m)-rpms
 ```
-
 Install runtime dependencies:
+
 ```bash
 sudo dnf -y install \
   conmon \
@@ -372,6 +372,12 @@ sudo dnf -y install \
   netavark \
   nftables \
   slirp4netns
+```
+
+On EL9 derivatives (such as CentOS Stream 9), install `catatonit` from the CRB repository:
+
+```bash
+sudo dnf -y install catatonit --enablerepo=crb
 ```
 
 Debian, Ubuntu, and related distributions:


### PR DESCRIPTION
#### Concisely describe the change

Added a missing documentation step for installing `catatonit` on EL9 derivatives when building Podman from source. This addresses the missing runtime dependency installation mentioned in issue #274.

#### Before screenshot / screen recording

N/A (documentation change only)

#### After screenshot / screen recording

N/A (documentation change only)

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`)
- [x] Referenced issues using `Fixes: #274` in commit message (if applicable)
- [x] PR description, commit message, and GitHub comments are human-written, per LLM Policy