### PR TITLE
The leading '0 ' in the class string is a syntax typo that gets evaluated as a class name "0"

### DIFF
--- a/src/components/content/FeaturesCarousel/index.tsx
+++ b/src/components/content/FeaturesCarousel/index.tsx
@@ -11,7 +11,7 @@ const Tab = (props): JSX.Element => {
       ${
         isActive
           ? 'bg-gradient-radial from-purple-500 to-purple-700 text-white dark:from-purple-700 dark:to-purple-900 dark:shadow-purple-900'
-          : '0 bg-white text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:shadow-gray-700'
+          : 'bg-white text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:shadow-gray-700'
       }`}>
       <h4 className="text-blue-500 dark:text-blue-500">{label}</h4>
       <ul>


### PR DESCRIPTION
Closes #638 

Typo in Tailwind Class String
* **File Reference:** [FeaturesCarousel/index.tsx](file:///c:/Users/Hp/podman.io/src/components/content/FeaturesCarousel/index.tsx#L14)
* **Code:** `'0 bg-white text-gray-700...'`
* **Reason:** The leading `'0 '` in the class string is a syntax typo that gets evaluated as a class name `"0"`. While harmless in some browsers, it introduces invalid markup and shows that styling classes are not fully sanitized.