### PR TITLE
Null-Pointer Crash on Empty Meeting Lists

### DIFF
--- a/src/components/content/FeaturesCarousel/index.tsx
+++ b/src/components/content/FeaturesCarousel/index.tsx
@@ -11,7 +11,7 @@ const Tab = (props): JSX.Element => {
       ${
         isActive
           ? 'bg-gradient-radial from-purple-500 to-purple-700 text-white dark:from-purple-700 dark:to-purple-900 dark:shadow-purple-900'
-          : '0 bg-white text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:shadow-gray-700'
+          : 'bg-white text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:shadow-gray-700'
       }`}>
       <h4 className="text-blue-500 dark:text-blue-500">{label}</h4>
       <ul>

--- a/src/components/layout/CommunityMeetingsCardGrid/index.tsx
+++ b/src/components/layout/CommunityMeetingsCardGrid/index.tsx
@@ -165,30 +165,34 @@ function CommunityMeetingsCardGrid({ cards }) {
 
   // get top 2 CommunityMeetings & CabalMeetings for subcards
   for (let i = 0; i < 2; i++) {
-    let meeting = MeetingDropdownOptions.shift();
-    communityMeetingsData.push({
-      date: meeting?.date,
-      icon: 'film-icon',
-      buttons: [
-        {
-          path: meeting?.meeting_recording?.link,
-          text: meeting?.meeting_recording?.text,
-        },
-        { ...meeting?.meeting_minutes },
-      ],
-    });
-    meeting = cabalDropdownOptions.shift();
-    CabalMeetingsData.push({
-      date: meeting?.date,
-      icon: 'film-icon',
-      buttons: [
-        {
-          path: meeting?.meeting_recording?.link,
-          text: meeting?.meeting_recording?.text,
-        },
-        { ...meeting?.meeting_minutes },
-      ],
-    });
+    const meeting = MeetingDropdownOptions.shift();
+    if (meeting) {
+      communityMeetingsData.push({
+        date: meeting.date,
+        icon: 'film-icon',
+        buttons: [
+          {
+            path: meeting.meeting_recording?.link,
+            text: meeting.meeting_recording?.text,
+          },
+          { ...meeting.meeting_minutes },
+        ],
+      });
+    }
+    const cabalMeeting = cabalDropdownOptions.shift();
+    if (cabalMeeting) {
+      CabalMeetingsData.push({
+        date: cabalMeeting.date,
+        icon: 'film-icon',
+        buttons: [
+          {
+            path: cabalMeeting.meeting_recording?.link,
+            text: cabalMeeting.meeting_recording?.text,
+          },
+          { ...cabalMeeting.meeting_minutes },
+        ],
+      });
+    }
   }
 
   return (


### PR DESCRIPTION
Closes #639 
* **File Reference:** [CommunityMeetingsCardGrid/index.tsx](file:///c:/Users/Hp/podman.io/src/components/layout/CommunityMeetingsCardGrid/index.tsx)
* **Code Pointer:**
  ```typescript
  for (let i = 0; i < 2; i++) {
    let meeting = MeetingDropdownOptions.shift();
    communityMeetingsData.push({
      date: meeting?.date,
  ```

  ```
* **Technical Reason & Impact:** The component shifts items out of lists without validating their lengths first. If an array is empty or holds a single item, `shift()` yields `undefined`. Consequently, `SubcardGrid` passes `undefined` to the `Date` constructor, returning `NaN`. `DayOfTheWeek` then returns `undefined`, which gets passed into children components, producing empty links and text sections.

