### PR TITLE
Render markdown during the static build

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,6 @@ _Text and Images_
 - Linting: [Eslint](https://eslint.org/) (see `.eslintrc`, `.eslintignore`)
 - Rendering markdown from js strings: [react markdown parser](https://github.com/remarkjs/react-markdown)
   - Use the custom `<Markdown text="..." styles="..." /> component for any markdown strings
-    - This component wraps the markdown parser in `<BrowserOnly>{() => <ReactMarkdown />}</BrowserOnly>` and handles the lazy loading and imports, reducing the amount of code needed on each instance.
+    - This component wraps the markdown parser and handles the import, reducing the amount of code needed on each instance. It renders during the static build, so the text ends up in the generated HTML.
 - Rendering html from wordpress: [html-react-parser](https://www.npmjs.com/package/html-react-parser)
   - Use this to render any injected html to avoid XSS

--- a/src/components/utilities/Markdown/index.tsx
+++ b/src/components/utilities/Markdown/index.tsx
@@ -1,25 +1,12 @@
-import React, { lazy, Suspense } from 'react';
-import BrowserOnly from '@docusaurus/BrowserOnly';
-// const rehypeRaw = lazily(() => import('rehype-raw'));
-const ReactMarkdown = lazy(() => import('react-markdown'));
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+
 interface Props {
   text: string;
   styles?: string;
 }
 
-const fallBackComponent = () => {
-  return <p>text loading...</p>;
-};
-// rehypePlugins={[rehypeRaw] as any}
 function Markdown({ text, styles }: Props): JSX.Element {
-  return (
-    <BrowserOnly>
-      {() => (
-        <Suspense fallback={fallBackComponent()}>
-          <ReactMarkdown children={text} className={styles} />
-        </Suspense>
-      )}
-    </BrowserOnly>
-  );
+  return <ReactMarkdown children={text} className={styles} />;
 }
 export default Markdown;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,8 @@
   "extends": "@tsconfig/docusaurus/tsconfig.json",
   "compilerOptions": {
     "jsx": "react",
+    "module": "esnext",
+    "moduleResolution": "node",
     "typeRoots": ["node_modules/@types", "src/types"],
     "baseUrl": "."
   }


### PR DESCRIPTION
Fixes #648

`Markdown` wrapped ReactMarkdown in `BrowserOnly`, which renders nothing during the static build. So any text passed through it was missing from the HTML and only appeared after hydration. 19 call sites, including `PageHeader` and `SectionHeader`.

**Before**

```
$ curl -s https://podman.io/features | grep -c "Podman makes it easy to find"
0
```

**After** (local build)

```
$ grep -c "Podman makes it easy to find" build/features.html
1
```

Words of text in the HTML:

| page | before | after |
|---|---|---|
| / | 364 | 495 |
| /features | 414 | 525 |
| /community | 442 | 944 |
| /get-started | 718 | 826 |

/community went from 16 missing lines to 0.

**The tsconfig change.** react-markdown v8 is ESM only, and the base config sets `moduleResolution: Node16`, so a static import gives TS1479. This only affects `yarn typecheck`, the webpack build is fine either way. Setting `module: esnext` and `moduleResolution: node` clears it, and the error count is the same 6 pre-existing ones before and after. Happy to do this another way if you would rather not touch tsconfig.

This also looks like the original reason for the dynamic import. React 17 cannot render Suspense on the server, which is what #18 ran into in 2023.

**Checked:** `yarn build` passes, no console errors on the built site, the `styles` prop still applies, and the bundle is slightly smaller without the lazy chunk (1026 to 1025 chunks).

**Notes:** the `BrowserOnly` in `HeroHeader` needs the browser for OS detection, so I left it. #524 touches the same file and will conflict, happy to rebase if that goes in first.

I used an LLM to help write this description. The work and the testing are mine and I can explain any of it.
