### PR TITLE
perf: replace scroll listener with IntersectionObserver

### DIFF
--- a/src/components/utilities/PlayOnScroll/index.tsx
+++ b/src/components/utilities/PlayOnScroll/index.tsx
@@ -7,27 +7,30 @@ interface VideoProps {
     posterImg?: string;
   }
 
-const PlayOnScroll: React.FC = (props: VideoProps) => {
+const PlayOnScroll: React.FC<VideoProps> = props => {
     const videoRef = useRef<HTMLVideoElement>(null);
-  
+
     useEffect(() => {
-      const handleScroll = () => {
-        if (videoRef.current) {
-          const rect = videoRef.current.getBoundingClientRect();
-          const isFullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
-          
-          if (isFullyVisible) {
-            videoRef.current.play();
+      const video = videoRef.current;
+      if (!video) {
+        return;
+      }
+
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) {
+            video.play().catch(() => {});
           } else {
-            videoRef.current.pause();
+            video.pause();
           }
-        }
-      };
-  
-      window.addEventListener('scroll', handleScroll);
-      
+        },
+        { threshold: 1 },
+      );
+
+      observer.observe(video);
+
       return () => {
-        window.removeEventListener('scroll', handleScroll);
+        observer.disconnect();
       };
     }, []);
   


### PR DESCRIPTION
#### Concisely describe the change

The PlayOnScroll component was checking getBoundingClientRect() on every scroll event to determine whether the video should play or pause. Since the component is mounted four times on /features, this meant four synchronous layout reads were happening on every scroll.

Replaced the scroll listener with an IntersectionObserver using a threshold of 1, keeping the same fully-visible behavior while avoiding the repeated layout reads during scrolling.

Verified with yarn typecheck and yarn build, and manually checked /features to make sure videos still play and pause correctly while scrolling.

Fixes: [#656](https://github.com/containers/podman.io/issues/656)

#### Before screenshot / screen recording
<img width="1844" height="747" alt="Screenshot 2026-08-09 000056" src="https://github.com/user-attachments/assets/7f4f23ec-3551-448a-87d0-befc8e76c395" />



#### After screenshot / screen recording

<img width="1824" height="792" alt="image" src="https://github.com/user-attachments/assets/7be3c305-1682-4997-947a-172696bc5e3e" />


#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
