### PR TITLE
chore: fix eslint configuration and install missing prettier plugin

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,8 +18,6 @@
   },
   "plugins": ["@typescript-eslint", "prettier"],
   "ignorePatterns": [
-    "packages/preload/exposedInMainWorld.d.ts",
-    "packages/preload-docker-extension/exposedInDockerExtension.d.ts",
     "node_modules/**",
     "**/dist/**"
   ],

--- a/package.json
+++ b/package.json
@@ -42,10 +42,11 @@
     "@typescript-eslint/parser": "^5.48.2",
     "eslint": "^8.32.0",
     "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-prettier": "^4.2.1",
     "husky": "^8.0.3",
     "lint-staged": "^13.1.0",
     "prettier": "2.8.8",
-    "prettier-plugin-tailwindcss": "^0.8.1",
+    "prettier-plugin-tailwindcss": "^0.2.8",
     "tailwind-scrollbar": "^3.0.0",
     "typescript": "^4.9.4"
   },

--- a/src/components/content/BasicResourcesBox/data.ts
+++ b/src/components/content/BasicResourcesBox/data.ts
@@ -1,22 +1,22 @@
 const resources = {
-    title: 'Basic Resources',
-    buttons: [
-      {
-        text: 'Installation Instructions',
-        path: 'docs/installation',
-        icon: 'fa6-solid:book',
-      },
-      {
-        text: 'Documentation',
-        path: 'https://docs.podman.io/en/latest/',
-        icon: 'fa6-solid:book',
-      },
-      {
-        text: 'Podman Troubleshooting Guide',
-        path: 'https://github.com/containers/podman/blob/main/troubleshooting.md',
-        icon: 'fa6-solid:book',
-      },
-    ],
-  };
+  title: 'Basic Resources',
+  buttons: [
+    {
+      text: 'Installation Instructions',
+      path: 'docs/installation',
+      icon: 'fa6-solid:book',
+    },
+    {
+      text: 'Documentation',
+      path: 'https://docs.podman.io/en/latest/',
+      icon: 'fa6-solid:book',
+    },
+    {
+      text: 'Podman Troubleshooting Guide',
+      path: 'https://github.com/containers/podman/blob/main/troubleshooting.md',
+      icon: 'fa6-solid:book',
+    },
+  ],
+};
 
-  export { resources };
+export { resources };

--- a/src/components/content/BasicResourcesBox/index.tsx
+++ b/src/components/content/BasicResourcesBox/index.tsx
@@ -15,7 +15,7 @@ const BasicResourcesBox = () => {
               <li key={index}>
                 <a
                   href={button.path}
-                  className="no-underline hover:no-underline leading-none mx-auto flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center text-purple-700 underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:shadow-md dark:bg-gray-700 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
+                  className="mx-auto flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center leading-none text-purple-700 no-underline underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:no-underline hover:shadow-md dark:bg-gray-700 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
                   <span className="text-left">{button.text}</span>
                   <Icon icon={button.icon} className="order-first hidden lg:block" />
                 </a>

--- a/src/components/content/CodeExampleSection/data.ts
+++ b/src/components/content/CodeExampleSection/data.ts
@@ -1,5 +1,5 @@
 const searchExample = {
-  command: `$ podman search httpd`,
+  command: '$ podman search httpd',
   // prettier-ignore
   code: ` 
   INDEX       NAME                                  DESCRIPTION                    STARS OFFICIAL AUTOMATED
@@ -13,10 +13,10 @@ const searchExample = {
 
 
 `,
-  label: `Podman can search for images on remote registries with some simple keywords.`,
+  label: 'Podman can search for images on remote registries with some simple keywords.',
 };
 const searchFilterExample = {
-  command: `$ podman search httpd --filter=is-official`,
+  command: '$ podman search httpd --filter=is-official',
   // prettier-ignore
   code:`
   INDEX       NAME                                  DESCRIPTION                    STARS OFFICIAL AUTOMATED
@@ -37,19 +37,20 @@ const searchFilterExample = {
 
 
 `,
-  label: `You can also enhance your search with filters.`,
-  extra: `Downloading (pulling) an image is easy, too.`,
+  label: 'You can also enhance your search with filters.',
+  extra: 'Downloading (pulling) an image is easy, too.',
 };
 const imagesExample = {
-  command: `$ podman images`,
+  command: '$ podman images',
   // prettier-ignore
   code:`
   REPOSITORY               TAG         IMAGE ID      CREATED       SIZE
   docker.io/library/httpd  latest      d294bb32c207  12 hours ago  148 MB
   
 `,
-  label: `Podman can search for images on remote registries with some simple keywords.`,
-  extra: `**Note**: Podman searches in different registries. Therefore it is recommend to use the full image name (docker.io/library/httpd instead of httpd) to ensure that you are using the correct image.`,
+  label: 'Podman can search for images on remote registries with some simple keywords.',
+  extra:
+    '**Note**: Podman searches in different registries. Therefore it is recommend to use the full image name (docker.io/library/httpd instead of httpd) to ensure that you are using the correct image.',
 };
 
 export { searchExample, searchFilterExample, imagesExample };

--- a/src/components/content/TestimonialSection/index.tsx
+++ b/src/components/content/TestimonialSection/index.tsx
@@ -38,11 +38,7 @@ function TestimonialSection() {
             return <Testimonial key={index} {...testimonial} />;
           })}
         </div>
-        <button
-          type="button"
-          onClick={slideRight}
-          className="hidden sm:block xl:hidden"
-          aria-label="Next testimonial">
+        <button type="button" onClick={slideRight} className="hidden sm:block xl:hidden" aria-label="Next testimonial">
           <Icon
             icon="fa-solid:arrow-circle-right"
             className="dark:hover-text-purple-700 text-4xl text-gray-500 opacity-25 transition duration-150 ease-linear hover:text-purple-900 hover:opacity-100"

--- a/src/components/content/ThankYouSection/data.ts
+++ b/src/components/content/ThankYouSection/data.ts
@@ -5,7 +5,7 @@ const sponsorData = [
     src: 'logos/optimized/red-hat-120w-77h.webp',
     alt: 'Red Hat Logo',
   },
-   {
+  {
     label: 'Amadeus',
     href: 'https://www.amadeus.com/',
     src: 'logos/optimized/amadeus-171w-22h.webp',

--- a/src/components/content/ThankYouSection/index.tsx
+++ b/src/components/content/ThankYouSection/index.tsx
@@ -29,7 +29,7 @@ function ThankYouSection(): JSX.Element {
         </button>
         <div
           id="slider"
-          className="justify-center mx-auto h-full w-full  place-items-center gap-6 overflow-x-scroll scroll-smooth whitespace-nowrap scrollbar scrollbar-track-purple-500 lg:container lg:grid">
+          className="mx-auto h-full w-full place-items-center  justify-center gap-6 overflow-x-scroll scroll-smooth whitespace-nowrap scrollbar scrollbar-track-purple-500 lg:container lg:grid">
           <a
             href={redHat.href}
             target="_blank"

--- a/src/components/content/WelcomeBanner/index.tsx
+++ b/src/components/content/WelcomeBanner/index.tsx
@@ -18,8 +18,8 @@ function WelcomeBanner() {
         </div>
         <div className="col-span-full mt-8 flex flex-wrap items-center gap-8 md:mt-0 lg:col-span-8 ">
           <p className="max-w-prose text-center text-white">
-            Take a look around, don't forget to check out the new <a href="docs">docs layout</a>. Please report
-            any bugs to <a href="https://github.com/containers/website-new/issues">the issue tracker</a>.
+            Take a look around, don't forget to check out the new <a href="docs">docs layout</a>. Please report any bugs
+            to <a href="https://github.com/containers/website-new/issues">the issue tracker</a>.
           </p>
         </div>
       </div>

--- a/src/components/layout/CommunityMeetingsCardGrid/index.tsx
+++ b/src/components/layout/CommunityMeetingsCardGrid/index.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode, useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import CustomCard from '@site/src/components/ui/CustomCard';
 import SubcardGrid from '@site/src/components/layout/SubcardGrid';
 import SectionHeader from '@site/src/components/layout/SectionHeader';
@@ -38,7 +39,7 @@ type SubcardButtonProps = {
   text: string;
   path?: string;
   markDown?: ReactNode;
-  modalHeaderData?: String;
+  modalHeaderData?: string;
 };
 
 type SubcardGridProps = {
@@ -65,8 +66,8 @@ function toggleModalOpen(ref, handler) {
 }
 
 function CommunityMeetingsCardGrid({ cards }) {
-  let cabalDropdownOptions: DropdownOptionProps[] = [];
-  let MeetingDropdownOptions: DropdownOptionProps[] = [];
+  const cabalDropdownOptions: DropdownOptionProps[] = [];
+  const MeetingDropdownOptions: DropdownOptionProps[] = [];
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalHeader, setModalHeader] = useState<ReactNode | undefined>(undefined);
@@ -91,10 +92,10 @@ function CommunityMeetingsCardGrid({ cards }) {
 
   const populateMeetings = (): void => {
     Object.values(markDownFiles)?.forEach(mdFile => {
-      let mdReader = mdFile?.default(useRef());
+      const mdReader = mdFile?.default(useRef());
       mdReader?.props?.children?.forEach(child => {
-        let field1: string = child?.props?.children?.[0];
-        let field2: object = child?.props?.children?.[1];
+        const field1: string = child?.props?.children?.[0];
+        const field2: object = child?.props?.children?.[1];
         if (typeof field1 == 'string' && (field1.includes('BlueJeans') || field1.includes('Video'))) {
           if (mdFile?.contentTitle?.includes('Cabal')) {
             cabalDropdownOptions.unshift({
@@ -160,8 +161,8 @@ function CommunityMeetingsCardGrid({ cards }) {
 
   populateMeetings();
 
-  let communityMeetingsData: SubcardGridProps[] = [];
-  let CabalMeetingsData: SubcardGridProps[] = [];
+  const communityMeetingsData: SubcardGridProps[] = [];
+  const CabalMeetingsData: SubcardGridProps[] = [];
 
   // get top 2 CommunityMeetings & CabalMeetings for subcards
   for (let i = 0; i < 2; i++) {
@@ -194,7 +195,7 @@ function CommunityMeetingsCardGrid({ cards }) {
   return (
     <div className="justify-content-center align-items-center custom-card-grid-root flex">
       {cards.map((card: CommunityMeetingsCardProps, index: number) => {
-        let meetingsData = index == 1 ? CabalMeetingsData : communityMeetingsData;
+        const meetingsData = index == 1 ? CabalMeetingsData : communityMeetingsData;
         return (
           <div
             key={`card-container-${index}`}

--- a/src/components/layout/HeroHeader/installOptions.ts
+++ b/src/components/layout/HeroHeader/installOptions.ts
@@ -2,7 +2,7 @@ import { LATEST_VERSION, LATEST_DESKTOP_VERSION } from '@site/static/data/global
 const operatingSystemData = [
   {
     id: 'windows',
-    preferred:{
+    preferred: {
       title: 'Podman Desktop for Windows',
       subtitle: `Windows Installer v-${LATEST_DESKTOP_VERSION}`,
       icon: 'fa-brands:windows',
@@ -39,7 +39,7 @@ const operatingSystemData = [
     },
     alt: {
       title: 'Podman CLI for macOS',
-      subtitle: `CLI only ARM64 installer`,
+      subtitle: 'CLI only ARM64 installer',
       icon: 'material-symbols:terminal-rounded',
       path: `https://github.com/podman-container-tools/podman/releases/download/v${LATEST_VERSION}/podman-installer-macos-arm64.pkg`,
     },
@@ -54,7 +54,7 @@ const operatingSystemData = [
       title: 'Podman CLI for Linux',
       subtitle: `Podman Engine v${LATEST_VERSION}`,
       icon: 'material-symbols:terminal-rounded',
-      path: `docs/installation#installing-on-linux`,
+      path: 'docs/installation#installing-on-linux',
     },
     alt: {
       title: 'Podman Desktop for Linux',

--- a/src/components/layout/PageHeader/index.tsx
+++ b/src/components/layout/PageHeader/index.tsx
@@ -14,17 +14,17 @@ type PageHeaderProps = LayoutProps &
     darkColor?: string;
     lightColor?: string;
     basicResources?: boolean;
-    instructions?: { [key:string]: any };
+    instructions?: { [key: string]: any };
   };
 
 type PageHeaderSupplementalInfoProps = PageHeaderProps & {
   image?: Image;
   basicResources?: boolean;
-}
+};
 
 type InstructionsProps = PageHeaderProps & {
-  instructions?: { [key:string]: any };
-}
+  instructions?: { [key: string]: any };
+};
 
 const TextBox = ({ grid, display, layout, title, description }: PageHeaderProps): JSX.Element => {
   return (
@@ -38,7 +38,7 @@ const TextBox = ({ grid, display, layout, title, description }: PageHeaderProps)
 const Image = ({
   grid,
   display,
-  layout,// if array then {[key:string]: any}[];
+  layout, // if array then {[key:string]: any}[];
   image = { path: 'images/optimized/podman-2-196w-172h.webp', alt: 'Podman Logo' },
 }: ImageSectionProps) => {
   return (
@@ -50,52 +50,55 @@ const Image = ({
 
 function PageHeaderSupplementalInfo({ image, basicResources }: PageHeaderSupplementalInfoProps) {
   if (basicResources) {
-    return (
-      <BasicResourcesBox />
-    );
-  } 
-  return (
-    <Image image={image} layout="mb-8 lg:mb-0" />
-  );
+    return <BasicResourcesBox />;
+  }
+  return <Image image={image} layout="mb-8 lg:mb-0" />;
 }
 
 function Instructions({ instructions }: InstructionsProps) {
   if (instructions) {
     return (
       <div>
-        <h3 className="text-gray-700 mb-4">{instructions.title}</h3>
+        <h3 className="mb-4 text-gray-700">{instructions.title}</h3>
         <p>{instructions.subtitle}</p>
-         <ul className="mb-10 mt-4 flex flex-col gap-6 sm:flex-row lg:mb-16 lg:gap-4 xl:flex-col">
-              <li>
-                <a
-                  href={instructions.button.path}
-                  className="no-underline hover:no-underline flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center text-purple-700 underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:shadow-md dark:bg-gray-700 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
-                  <span>{instructions.button.text}</span>
-                  <Icon icon={instructions.button.icon} className="order-first hidden lg:block" />
-                </a>
-              </li>
+        <ul className="mb-10 mt-4 flex flex-col gap-6 sm:flex-row lg:mb-16 lg:gap-4 xl:flex-col">
+          <li>
+            <a
+              href={instructions.button.path}
+              className="flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center text-purple-700 no-underline underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:no-underline hover:shadow-md dark:bg-gray-700 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
+              <span>{instructions.button.text}</span>
+              <Icon icon={instructions.button.icon} className="order-first hidden lg:block" />
+            </a>
+          </li>
         </ul>
       </div>
-    )
+    );
   }
   return null;
 }
 
-function PageHeader({ title, description, image, lightColor = 'white', darkColor = 'gray-900', basicResources, instructions }: PageHeaderProps) {
+function PageHeader({
+  title,
+  description,
+  image,
+  lightColor = 'white',
+  darkColor = 'gray-900',
+  basicResources,
+  instructions,
+}: PageHeaderProps) {
   return (
     <header className={`bg-${lightColor} dark:bg-${darkColor}`}>
       <div className="bg-gradient-to-r  from-blue-500 to-purple-700 dark:from-blue-700 dark:to-purple-900 lg:pt-8">
         <WaveBorder />
       </div>
-      <div className="container flex flex-col md:flex-row justify-around">
+      <div className="container flex flex-col justify-around md:flex-row">
         <div>
           <TextBox title={title} description={description} layout="mt-12 lg:mt-0 mb-8" />
           <Instructions instructions={instructions} />
         </div>
-        <div className="w-[50%] ml-24">
+        <div className="ml-24 w-[50%]">
           <PageHeaderSupplementalInfo basicResources={basicResources} />
         </div>
-
       </div>
     </header>
   );

--- a/src/components/layout/SubcardGrid/index.tsx
+++ b/src/components/layout/SubcardGrid/index.tsx
@@ -6,7 +6,7 @@ function SubcardGrid({ cards, toggleIsModalOpen }) {
   return (
     <div className="mb-4 flex lg:mb-6">
       {cards?.map((card, index) => {
-        let date = new Date(card.date).getDay();
+        const date = new Date(card.date).getDay();
         return (
           <CustomCard
             key={index}

--- a/src/components/shapes/FilmIcon/index.tsx
+++ b/src/components/shapes/FilmIcon/index.tsx
@@ -18,7 +18,7 @@ function FilmIcon() {
           className="svg-inline--fa fa-film fa-w-16"
           rx="0"
           ry="0"
-          fill={`url(#fill-0-rumext-id-2)`}>
+          fill={'url(#fill-0-rumext-id-2)'}>
           <defs>
             <radialGradient
               id="fill-color-gradient_rumext-id-2_0"
@@ -41,7 +41,7 @@ function FilmIcon() {
                 <rect
                   width="74.66667200000188"
                   height="56.00000799999998"
-                  fill={`url(#fill-color-gradient_rumext-id-2_0)`}
+                  fill={'url(#fill-color-gradient_rumext-id-2_0)'}
                 />
               </g>
             </pattern>
@@ -70,7 +70,7 @@ function FilmIcon() {
                   <rect
                     width="75.00000000000205"
                     height="56.000000000000455"
-                    fill={`url(#fill-color-gradient_rumext-id-3_0)`}
+                    fill={'url(#fill-color-gradient_rumext-id-3_0)'}
                   />
                 </g>
               </pattern>
@@ -90,7 +90,7 @@ function FilmIcon() {
           className="svg-inline--fa fa-film fa-w-16"
           rx="0"
           ry="0"
-          fill={`url(#fill-0-rumext-id-4)`}>
+          fill={'url(#fill-0-rumext-id-4)'}>
           <defs>
             <radialGradient
               id="fill-color-gradient_rumext-id-4_0"
@@ -113,7 +113,7 @@ function FilmIcon() {
                 <rect
                   width="74.66667200000188"
                   height="56.00000799999998"
-                  fill={`url(#fill-color-gradient_rumext-id-4_0)`}
+                  fill={'url(#fill-color-gradient_rumext-id-4_0)'}
                 />
               </g>
             </pattern>
@@ -142,7 +142,7 @@ function FilmIcon() {
                   <rect
                     width="75.00000000000205"
                     height="56.000000000000455"
-                    fill={`url(#fill-color-gradient_rumext-id-5_0)`}
+                    fill={'url(#fill-color-gradient_rumext-id-5_0)'}
                   />
                 </g>
               </pattern>

--- a/src/components/ui/ArticleCard/index.tsx
+++ b/src/components/ui/ArticleCard/index.tsx
@@ -34,13 +34,13 @@ const Title = (title: string) => {
 function ArticleCard(props: ArticleCardProps) {
   // Select fallback image based on index, cycling through available images
   const fallbackImage = FALLBACK_IMAGES[(props.index || 0) % FALLBACK_IMAGES.length];
-  
+
   // Sanitizes HTML and converts it to plain text
   const sanitizeHtml = (html: string) => {
     if (!html) return html;
-    const div = document.createElement("div");
+    const div = document.createElement('div');
     div.innerHTML = html;
-    return div.textContent || div.innerText || "";
+    return div.textContent || div.innerText || '';
   };
   const abbrSubtitle = sanitizeHtml(props.subtitle).trim().split(' ').slice(0, 32).join(' ').concat('...');
   if (props.altLayout) {

--- a/src/components/ui/CustomCard/index.tsx
+++ b/src/components/ui/CustomCard/index.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode } from 'react';
+import type { ReactNode } from 'react';
+import React from 'react';
 import Button from '@site/src/components/utilities/Button/';
 import Markdown from '@site/src/components/utilities/Markdown';
 import FilmIcon from '../../shapes/FilmIcon';
@@ -11,7 +12,7 @@ type SubcardButtonProps = {
 
 type CardInfoButtonProps = {
   data: SubcardButtonProps[];
-  primary: Boolean;
+  primary: boolean;
   method: Function;
 };
 

--- a/src/components/ui/Testimonial/index.tsx
+++ b/src/components/ui/Testimonial/index.tsx
@@ -14,27 +14,35 @@ type TestimonialProps = {
 
 function Testimonial(props: TestimonialProps) {
   return (
-    <article className="flex flex-col mx-2 my-4 max-w-sm rounded-sm bg-white p-4 shadow-lg dark:bg-gray-900">
-      <div className="flex items-center gap-3 mb-4">
+    <article className="mx-2 my-4 flex max-w-sm flex-col rounded-sm bg-white p-4 shadow-lg dark:bg-gray-900">
+      <div className="mb-4 flex items-center gap-3">
         <div className="m-2">
           <div className="flex items-center gap-2">
             <h3 className="text-lg font-bold">{props.name}</h3>
             <Icon icon={`logos:${props.social}`} className="text-2xl" />
           </div>
-          <a href={props.path} className=" text-gray-700 dark:text-gray-100 dark:hover:text-purple-900 no-underline hover:no-underline hover:bg-purple-300">
+          <a
+            href={props.path}
+            className=" text-gray-700 no-underline hover:bg-purple-300 hover:no-underline dark:text-gray-100 dark:hover:text-purple-900">
             {props.handle}
           </a>
         </div>
         <div className="order-first">
-          <img src={`${props.avatar}`} alt="user avatar" className="h-fit w-fit max-w-16 max-h-16 rounded-full" />
+          <img src={`${props.avatar}`} alt="user avatar" className="h-fit max-h-16 w-fit max-w-16 rounded-full" />
         </div>
       </div>
-      <div className="mt-2 mb-4 truncate">
-        <p className="whitespace-normal text-gray-900 dark:text-gray-300 leading-snug mb-2">{props.description}</p>
-        {props.featuredlink && <a target="_blank" href={props.featuredlink}>{props.featuredlink}</a>}
+      <div className="mb-4 mt-2 truncate">
+        <p className="mb-2 whitespace-normal leading-snug text-gray-900 dark:text-gray-300">{props.description}</p>
+        {props.featuredlink && (
+          <a target="_blank" href={props.featuredlink}>
+            {props.featuredlink}
+          </a>
+        )}
       </div>
-      <div className="mt-auto self-start text-gray-300 dark:text-gray-700 italic">
-        <a href={props.path} className="text-gray-300 dark:text-gray-700 dark:hover:text-gray-700 no-underline hover:no-underline hover:bg-purple-300">
+      <div className="mt-auto self-start italic text-gray-300 dark:text-gray-700">
+        <a
+          href={props.path}
+          className="text-gray-300 no-underline hover:bg-purple-300 hover:no-underline dark:text-gray-700 dark:hover:text-gray-700">
           {props.date}
         </a>
       </div>

--- a/src/components/utilities/Link/index.tsx
+++ b/src/components/utilities/Link/index.tsx
@@ -14,7 +14,7 @@ function Link({
   textColor = 'text-blue-700 dark:text-blue-500',
   hoverColor = 'hover:text-purple-700 hover:dark:text-purple-700',
   underline = 'underline underline-offset-4',
-  target = '_self'
+  target = '_self',
 }: LinkProps): JSX.Element {
   return (
     <a

--- a/src/components/utilities/PlayOnScroll/index.tsx
+++ b/src/components/utilities/PlayOnScroll/index.tsx
@@ -1,45 +1,45 @@
 import React, { useRef, useEffect } from 'react';
 
 interface VideoProps {
-    url: string;
-    vidFormat?: string;
-    styles?: string;
-    posterImg?: string;
-  }
+  url: string;
+  vidFormat?: string;
+  styles?: string;
+  posterImg?: string;
+}
 
 const PlayOnScroll: React.FC = (props: VideoProps) => {
-    const videoRef = useRef<HTMLVideoElement>(null);
-  
-    useEffect(() => {
-      const handleScroll = () => {
-        if (videoRef.current) {
-          const rect = videoRef.current.getBoundingClientRect();
-          const isFullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
-          
-          if (isFullyVisible) {
-            videoRef.current.play();
-          } else {
-            videoRef.current.pause();
-          }
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (videoRef.current) {
+        const rect = videoRef.current.getBoundingClientRect();
+        const isFullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
+
+        if (isFullyVisible) {
+          videoRef.current.play();
+        } else {
+          videoRef.current.pause();
         }
-      };
-  
-      window.addEventListener('scroll', handleScroll);
-      
-      return () => {
-        window.removeEventListener('scroll', handleScroll);
-      };
-    }, []);
-  
-    return (
-      <div>
-        <video className={props.styles} ref={videoRef} poster={props.posterImg} autoPlay>
-          <source src={props.url} type={props.vidFormat} />
-          {/* Add additional source elements for different video formats if needed */}
-          Your browser does not support the video tag.
-        </video>
-      </div>
-    );
-  };
-  
-  export default PlayOnScroll;
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  return (
+    <div>
+      <video className={props.styles} ref={videoRef} poster={props.posterImg} autoPlay>
+        <source src={props.url} type={props.vidFormat} />
+        {/* Add additional source elements for different video formats if needed */}
+        Your browser does not support the video tag.
+      </video>
+    </div>
+  );
+};
+
+export default PlayOnScroll;

--- a/src/hooks/useBlogPosts.ts
+++ b/src/hooks/useBlogPosts.ts
@@ -22,7 +22,7 @@ interface UseBlogPostsReturn {
   loading: boolean;
 }
 
-export const useBlogPosts = (limit: number = 4): UseBlogPostsReturn => {
+export const useBlogPosts = (limit = 4): UseBlogPostsReturn => {
   const [data, setData] = useState<BlogPost[]>([]);
   const [loading, setLoading] = useState(true);
 

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -225,12 +225,12 @@ function Community() {
       <InfoBanner
         description="**Searching for Podman Desktop Community Meetings?** [Click Here](https://podman-desktop.io/community#community-events) or visit the [official website](https://podman-desktop.io) to learn more."
         image={{
-          src: "logos/optimized/podman-desktop-logo-200w-198h.webp",
-          alt: "Podman Desktop Logo"
+          src: 'logos/optimized/podman-desktop-logo-200w-198h.webp',
+          alt: 'Podman Desktop Logo',
         }}
         styles="bg-purple-700 dark:bg-purple-900 text-white [&_img]:w-16 [&_img]:h-16  [&_a]:underline [&_a:hover]:text-purple-300"
         marginHeight="mt-8 lg:mt-16"
-      /> 
+      />
       <MailingListSection />
       <SubmitIssuesSection />
       <ThankYouSection />

--- a/src/pages/features.tsx
+++ b/src/pages/features.tsx
@@ -41,18 +41,27 @@ const PodmanDesktopSection = () => {
       <div className="align-center container flex justify-center">
         <div className="flex-row content-center">
           <h2 className="content-center">
-            <a className="hover:no-underline hover:text-white active:text-white visited:text-white dark:hover:text-white dark:active:text-white dark:visited:text-white text-4xl mb-5 px-5  bg-blue-500 no-underline text-white dark:bg-blue-700 dark:text-white" href="https://podman-desktop.io">Podman Desktop</a>
+            <a
+              className="mb-5 bg-blue-500 px-5 text-4xl text-white no-underline visited:text-white hover:text-white hover:no-underline active:text-white  dark:bg-blue-700 dark:text-white dark:visited:text-white dark:hover:text-white dark:active:text-white"
+              href="https://podman-desktop.io">
+              Podman Desktop
+            </a>
           </h2>
         </div>
       </div>
-      <div className="container flex flex-col md:flex-row items-center">
+      <div className="container flex flex-col items-center md:flex-row">
         <div id="imgdiv" className="mx-auto w-full md:w-auto">
           <img id="pdlogo" className="mx-auto" src="logos/optimized/podman-desktop-logo-200w-198h.webp" />
         </div>
         <div className="md:w-1/2 xl:w-3/4">
           <p className="my-8 align-middle text-2xl leading-relaxed">
-            <a className="font-semibold hover:text-purple-500 text-purple-900 no-underline text-2xl leading-releaxed" href="https://podman-desktop.io">Podman Desktop</a> is Podman's graphical application that makes it easy to install and work with Podman (and
-            other container engines) on Windows, MacOS, and Linux.
+            <a
+              className="leading-releaxed text-2xl font-semibold text-purple-900 no-underline hover:text-purple-500"
+              href="https://podman-desktop.io">
+              Podman Desktop
+            </a>{' '}
+            is Podman's graphical application that makes it easy to install and work with Podman (and other container
+            engines) on Windows, MacOS, and Linux.
           </p>
         </div>
       </div>
@@ -62,22 +71,27 @@ const PodmanDesktopSection = () => {
 
 const ManageContainersUISection = () => {
   return (
-    <section className="xl:py-16 xl:flex xl:flex-row-reverse bg-gradient-to-b from-purple-100 to-purple-300 dark:from-black dark:to-gray-900">
-      <div className="flex-1 w-full md:my-16 md:w-4/5 md:mx-auto lg:w-full xl:my-16">
-        <PlayOnScroll vidFormat="video/mp4" url="video/ui/containers.mp4" posterImg="images/optimized/ui-screens/ui-manage-containers.webp" styles="rounded-lg w-full lg:w-3/4 lg:mx-auto xl:mr-0 xl:w-full max-w-[1200px] items-center md:rounded-3xl bg-cover md:bg-contain xl:rounded-r-none" />
+    <section className="bg-gradient-to-b from-purple-100 to-purple-300 dark:from-black dark:to-gray-900 xl:flex xl:flex-row-reverse xl:py-16">
+      <div className="w-full flex-1 md:mx-auto md:my-16 md:w-4/5 lg:w-full xl:my-16">
+        <PlayOnScroll
+          vidFormat="video/mp4"
+          url="video/ui/containers.mp4"
+          posterImg="images/optimized/ui-screens/ui-manage-containers.webp"
+          styles="rounded-lg w-full lg:w-3/4 lg:mx-auto xl:mr-0 xl:w-full max-w-[1200px] items-center md:rounded-3xl bg-cover md:bg-contain xl:rounded-r-none"
+        />
       </div>
-      <div className="flex flex-1 my-16 md:my-none">
-        <div className="flex-row px-16 xl:p-16 x2l:my-16 md:w-4/5 md:mx-auto">
+      <div className="md:my-none my-16 flex flex-1">
+        <div className="x2l:my-16 flex-row px-16 md:mx-auto md:w-4/5 xl:p-16">
           <h3 className="mb-5 dark:text-white">Manage containers (not just Podman.)</h3>
           <p className="mb-3 dark:text-white">
-            Podman Desktop allows you to list, view, and manage containers from multiple supported container
-            engines* in a single unified view.
+            Podman Desktop allows you to list, view, and manage containers from multiple supported container engines* in
+            a single unified view.
           </p>
           <p className="mb-3 dark:text-white">
             Gain easy access to a shell inside the container, logs, and basic controls.
           </p>
           <em className="mt-10 block dark:text-white">
-            * Supported engines and orchestrators include Podman, Docker, Lima, kind, Red Hat OpenShift, Red Hat 
+            * Supported engines and orchestrators include Podman, Docker, Lima, kind, Red Hat OpenShift, Red Hat
             OpenShift Developer Sandbox.
           </em>
         </div>
@@ -88,63 +102,78 @@ const ManageContainersUISection = () => {
 
 const BuildImagesUISection = () => {
   return (
-  <section className="xl:py-16 xl:flex xl:flex-row bg-gradient-to-b from-purple-100 to-purple-300 dark:from-black dark:to-gray-900 xl:dark:from-gray-900 xl:dark:to-black">
-    <div className="flex-1 w-full md:my-16 md:w-4/5 md:mx-auto lg:w-full xl:my-16">
-      <PlayOnScroll vidFormat="video/mp4" url="video/ui/images.mp4" posterImg="images/optimized/ui-screens/ui-buildimage.webp" styles="rounded-lg w-full lg:w-3/4 lg:mx-auto xl:ml-0 xl:w-full max-w-[1200px] items-center md:rounded-3xl bg-cover md:bg-contain xl:rounded-l-none" />
-    </div>
-    <div className="flex flex-1 my-16 md:my-none">
-      <div className="flex-row px-16 xl:p-16 x2l:my-16 md:w-4/5 md:mx-auto">
-        <h3 className="mb-5 dark:text-white">Build, pull, and push images.</h3>
-        <p className="mb-3 dark:text-white">
-          Build containers from a Dockerfile / Containerfile, or pull images from remote repositories to run.
-        </p>
-        <p className="mb-3 dark:text-white">
-          Manage accounts for and push your images to multiple container registries.
-        </p>
+    <section className="bg-gradient-to-b from-purple-100 to-purple-300 dark:from-black dark:to-gray-900 xl:flex xl:flex-row xl:py-16 xl:dark:from-gray-900 xl:dark:to-black">
+      <div className="w-full flex-1 md:mx-auto md:my-16 md:w-4/5 lg:w-full xl:my-16">
+        <PlayOnScroll
+          vidFormat="video/mp4"
+          url="video/ui/images.mp4"
+          posterImg="images/optimized/ui-screens/ui-buildimage.webp"
+          styles="rounded-lg w-full lg:w-3/4 lg:mx-auto xl:ml-0 xl:w-full max-w-[1200px] items-center md:rounded-3xl bg-cover md:bg-contain xl:rounded-l-none"
+        />
       </div>
-    </div>
-  </section>
+      <div className="md:my-none my-16 flex flex-1">
+        <div className="x2l:my-16 flex-row px-16 md:mx-auto md:w-4/5 xl:p-16">
+          <h3 className="mb-5 dark:text-white">Build, pull, and push images.</h3>
+          <p className="mb-3 dark:text-white">
+            Build containers from a Dockerfile / Containerfile, or pull images from remote repositories to run.
+          </p>
+          <p className="mb-3 dark:text-white">
+            Manage accounts for and push your images to multiple container registries.
+          </p>
+        </div>
+      </div>
+    </section>
   );
 };
 
 const CreatePodsUISection = () => {
   return (
-    <section className="xl:py-16 xl:flex xl:flex-row-reverse bg-gradient-to-b from-purple-100 to-purple-300 dark:from-black dark:to-gray-900">
-    <div className="flex-1 w-full md:my-16 md:w-4/5 md:mx-auto lg:w-full xl:my-16">
-      <PlayOnScroll vidFormat="video/mp4" url="video/ui/podify.mp4" posterImg="images/optimized/ui-screens/ui-podify.webp" styles="rounded-lg w-full lg:w-3/4 lg:mx-auto xl:mr-0 xl:w-full max-w-[1200px] items-center md:rounded-3xl bg-cover md:bg-contain xl:rounded-r-none" />
-    </div>
-    <div className="flex flex-1 my-16 md:my-none">
-      <div className="flex-row px-16 xl:p-16 x2l:my-16 md:w-4/5 md:mx-auto">
-        <h3 className="mb-5 dark:text-white">Podify containers into pods.</h3>
-        <p className="mb-3 dark:text-white">
-          Create pods by selecting containers to run together. View unified logs for your pods and inspect the
-          containers inside each.
-        </p>
-        <p className="mb-3 dark:text-white">
-        Play Kubernetes YAML locally, without Kubernetes, and generate Kubernetes YAML from Pods.
-        </p>
+    <section className="bg-gradient-to-b from-purple-100 to-purple-300 dark:from-black dark:to-gray-900 xl:flex xl:flex-row-reverse xl:py-16">
+      <div className="w-full flex-1 md:mx-auto md:my-16 md:w-4/5 lg:w-full xl:my-16">
+        <PlayOnScroll
+          vidFormat="video/mp4"
+          url="video/ui/podify.mp4"
+          posterImg="images/optimized/ui-screens/ui-podify.webp"
+          styles="rounded-lg w-full lg:w-3/4 lg:mx-auto xl:mr-0 xl:w-full max-w-[1200px] items-center md:rounded-3xl bg-cover md:bg-contain xl:rounded-r-none"
+        />
       </div>
-    </div>
-  </section>
+      <div className="md:my-none my-16 flex flex-1">
+        <div className="x2l:my-16 flex-row px-16 md:mx-auto md:w-4/5 xl:p-16">
+          <h3 className="mb-5 dark:text-white">Podify containers into pods.</h3>
+          <p className="mb-3 dark:text-white">
+            Create pods by selecting containers to run together. View unified logs for your pods and inspect the
+            containers inside each.
+          </p>
+          <p className="mb-3 dark:text-white">
+            Play Kubernetes YAML locally, without Kubernetes, and generate Kubernetes YAML from Pods.
+          </p>
+        </div>
+      </div>
+    </section>
   );
 };
 
 const DeployToKubernetesUISection = () => {
   return (
-  <section className="xl:py-16 md:pb-32 xl:flex xl:flex-row bg-gradient-to-b from-purple-100 to-purple-300  dark:from-black dark:to-gray-900 xl:dark:from-gray-900 xl:dark:to-black">
-    <div className="flex-1 w-full md:my-16 md:w-4/5 md:mx-auto lg:w-full xl:my-16">
-      <PlayOnScroll vidFormat="video/mp4" url="video/ui/kubernetes.mp4" posterImg="images/optimized/ui-screens/ui-k8sdeploy.webp" styles="rounded-lg w-full lg:w-3/4 lg:mx-auto xl:ml-0 xl:w-full max-w-[1200px] items-center md:rounded-3xl bg-cover md:bg-contain xl:rounded-l-none" />
-    </div>
-    <div className="flex flex-1 my-16 md:my-none">
-      <div className="flex-row px-16 xl:p-16 x2l:my-16 md:w-4/5 md:mx-auto">
-        <h3 className="mb-5 dark:text-white">Deploy to Kubernetes.</h3>
-        <p className="mb-3 dark:text-white">
-          Deploy pods from Podman Desktop to local or remote Kubernetes contexts using automatically-generated
-          YAML config.
-        </p>
+    <section className="bg-gradient-to-b from-purple-100 to-purple-300 dark:from-black dark:to-gray-900 md:pb-32 xl:flex  xl:flex-row xl:py-16 xl:dark:from-gray-900 xl:dark:to-black">
+      <div className="w-full flex-1 md:mx-auto md:my-16 md:w-4/5 lg:w-full xl:my-16">
+        <PlayOnScroll
+          vidFormat="video/mp4"
+          url="video/ui/kubernetes.mp4"
+          posterImg="images/optimized/ui-screens/ui-k8sdeploy.webp"
+          styles="rounded-lg w-full lg:w-3/4 lg:mx-auto xl:ml-0 xl:w-full max-w-[1200px] items-center md:rounded-3xl bg-cover md:bg-contain xl:rounded-l-none"
+        />
       </div>
-    </div>
-  </section>
+      <div className="md:my-none my-16 flex flex-1">
+        <div className="x2l:my-16 flex-row px-16 md:mx-auto md:w-4/5 xl:p-16">
+          <h3 className="mb-5 dark:text-white">Deploy to Kubernetes.</h3>
+          <p className="mb-3 dark:text-white">
+            Deploy pods from Podman Desktop to local or remote Kubernetes contexts using automatically-generated YAML
+            config.
+          </p>
+        </div>
+      </div>
+    </section>
   );
 };
 

--- a/src/pages/get-started.tsx
+++ b/src/pages/get-started.tsx
@@ -67,77 +67,112 @@ const SearchPullListSection = () => {
 
 const RunListContainersSection = () => {
   return (
-    <section className="bg-gradient-to-br from-blue-500/75 to-blue-700 dark:bg-blue-900 dark:text-white pt-6 pb-16" >
-      <SectionHeader textColor="text-purple-700 dark:text-purple-500" title="Running a container &amp; listing running containers" />
-      <div className="text-center flex flex-col mx-4">
-        <p className="mb-4">This sample container will run a very basic httpd server that serves only its index page.</p>
-        
-        <h3 className="text-purple-700 dark:text-purple-300 mb-2 mt-10">Running a container</h3>
+    <section className="bg-gradient-to-br from-blue-500/75 to-blue-700 pb-16 pt-6 dark:bg-blue-900 dark:text-white">
+      <SectionHeader
+        textColor="text-purple-700 dark:text-purple-500"
+        title="Running a container &amp; listing running containers"
+      />
+      <div className="mx-4 flex flex-col text-center">
+        <p className="mb-4">
+          This sample container will run a very basic httpd server that serves only its index page.
+        </p>
+
+        <h3 className="mb-2 mt-10 text-purple-700 dark:text-purple-300">Running a container</h3>
 
         <div className="mx-auto">
-          <CodeBlock language="bash" showLineNumbers className="text-left overflow-scroll xl:max-w-6xl max-w-xs sm:max-w-md md:max-w-lg lg:max-w-4xl">
+          <CodeBlock
+            language="bash"
+            showLineNumbers
+            className="max-w-xs overflow-scroll text-left sm:max-w-md md:max-w-lg lg:max-w-4xl xl:max-w-6xl">
             $ podman run -dt -p 8080:80/tcp docker.io/library/httpd {'\n'}
           </CodeBlock>
         </div>
 
         <div className="mx-auto max-w-lg rounded-md bg-white/50 px-6 py-6 shadow-lg dark:bg-gray-900/50">
           <h5 className="text-gray-700">Note:</h5>
-          <p className="text-gray-700 text-left">
-            Because the container is being run in detached mode, represented by the -d in the podman run command, 
-            Podman will run the container in the background and print the container ID after it has executed the 
-            command. The -t also adds a pseudo-tty to run arbitrary commands in an interactive shell.
+          <p className="text-left text-gray-700">
+            Because the container is being run in detached mode, represented by the -d in the podman run command, Podman
+            will run the container in the background and print the container ID after it has executed the command. The
+            -t also adds a pseudo-tty to run arbitrary commands in an interactive shell.
           </p>
-          <p className="text-gray-700 text-left mt-4">
-            Also, we use port forwarding to be able to access the HTTP server. For successful running at least <strong>slirp4netns</strong> v0.3.0 is needed.
+          <p className="mt-4 text-left text-gray-700">
+            Also, we use port forwarding to be able to access the HTTP server. For successful running at least{' '}
+            <strong>slirp4netns</strong> v0.3.0 is needed.
           </p>
         </div>
 
-        <h3 className="text-purple-700 dark:text-purple-300 mt-16 mb-2">Listing running containers</h3>
-      
+        <h3 className="mb-2 mt-16 text-purple-700 dark:text-purple-300">Listing running containers</h3>
+
         <div className="mx-auto">
-          <p className="text-gray-700 mb-4">The <code>podman ps</code> command is used to list created and running containers.</p>
-          <CodeBlock language="bash" showLineNumbers className="sm:bg-gray-100 text-left mx-4 overflow-scroll xl:max-w-6xl max-w-xs sm:max-w-md md:max-w-lg lg:max-w-4xl">
+          <p className="mb-4 text-gray-700">
+            The <code>podman ps</code> command is used to list created and running containers.
+          </p>
+          <CodeBlock
+            language="bash"
+            showLineNumbers
+            className="mx-4 max-w-xs overflow-scroll text-left sm:max-w-md sm:bg-gray-100 md:max-w-lg lg:max-w-4xl xl:max-w-6xl">
             $ podman ps{'\n'}
-            CONTAINER ID  IMAGE                           COMMAND           CREATED       STATUS      PORTS                 NAMES{'\n'}
-            01c44968199f  docker.io/library/httpd:latest  httpd-foreground  1 minute ago  Up 1 minute 0.0.0.0:8080-{'>'}80/tcp  laughing_bob{'\n'}
+            CONTAINER ID IMAGE COMMAND CREATED STATUS PORTS NAMES{'\n'}
+            01c44968199f docker.io/library/httpd:latest httpd-foreground 1 minute ago Up 1 minute 0.0.0.0:8080-{'>'}
+            80/tcp laughing_bob{'\n'}
           </CodeBlock>
           <div className="mx-auto max-w-lg rounded-md bg-white/50 px-6 py-6 shadow-lg dark:bg-gray-900/50">
             <h5 className="text-gray-700">Note:</h5>
-            <p className="text-gray-700 text-left">
-             If you add <code>-a</code> to the <code>podman ps</code> command, Podman will show all containers (created, exited, running, etc.).
+            <p className="text-left text-gray-700">
+              If you add <code>-a</code> to the <code>podman ps</code> command, Podman will show all containers
+              (created, exited, running, etc.).
             </p>
           </div>
         </div>
-     
-      <h3 className="text-purple-700 dark:text-purple-300 mt-16 mb-2">Testing the <code>httpd</code> container</h3>
-     
-      <div className="mx-auto">
-        <p className="text-gray-700 mb-4 text-left max-w-prose">As you are able to see, the container does not have an IP Address assigned. The container is reachable via its published port on your local machine.</p>
-        <CodeBlock language="bash" showLineNumbers className="sm:bg-gray-100 text-left mx-auto overflow-scroll xl:max-w-6xl max-w-xs sm:max-w-md md:max-w-lg lg:max-w-4xl">
-          $ curl http://localhost:8080{'\n'}
-        </CodeBlock>
 
-        <p className="text-gray-700 mb-4 max-w-prose text-left">From another machine, you need to use the IP Address of the host, running the container.</p>
-        <CodeBlock language="bash" showLineNumbers className="sm:bg-gray-100 text-left mx-auto overflow-scroll xl:max-w-6xl max-w-xs sm:max-w-md md:max-w-lg lg:max-w-4xl">
-          $ curl http://{'<IP_Address>'}:8080{'\n'}
-        </CodeBlock>
+        <h3 className="mb-2 mt-16 text-purple-700 dark:text-purple-300">
+          Testing the <code>httpd</code> container
+        </h3>
 
-        <div className="mx-auto max-w-lg rounded-md bg-white/50 px-6 py-6 shadow-lg dark:bg-gray-900/50">
-          <h5 className="text-gray-700">Note:</h5>
-          <p className="text-gray-700 text-left">
-          Instead of using <code>curl</code>, you can also point a browser to <code>http://localhost:8080</code>.</p>
+        <div className="mx-auto">
+          <p className="mb-4 max-w-prose text-left text-gray-700">
+            As you are able to see, the container does not have an IP Address assigned. The container is reachable via
+            its published port on your local machine.
+          </p>
+          <CodeBlock
+            language="bash"
+            showLineNumbers
+            className="mx-auto max-w-xs overflow-scroll text-left sm:max-w-md sm:bg-gray-100 md:max-w-lg lg:max-w-4xl xl:max-w-6xl">
+            $ curl http://localhost:8080{'\n'}
+          </CodeBlock>
+
+          <p className="mb-4 max-w-prose text-left text-gray-700">
+            From another machine, you need to use the IP Address of the host, running the container.
+          </p>
+          <CodeBlock
+            language="bash"
+            showLineNumbers
+            className="mx-auto max-w-xs overflow-scroll text-left sm:max-w-md sm:bg-gray-100 md:max-w-lg lg:max-w-4xl xl:max-w-6xl">
+            $ curl http://{'<IP_Address>'}:8080{'\n'}
+          </CodeBlock>
+
+          <div className="mx-auto max-w-lg rounded-md bg-white/50 px-6 py-6 shadow-lg dark:bg-gray-900/50">
+            <h5 className="text-gray-700">Note:</h5>
+            <p className="text-left text-gray-700">
+              Instead of using <code>curl</code>, you can also point a browser to <code>http://localhost:8080</code>.
+            </p>
+          </div>
         </div>
       </div>
-    </div>
     </section>
-  )
-}
+  );
+};
 
 /* PAGE CONTENT */
 function GetStarted() {
   return (
     <Layout>
-      <PageHeader title={header.title} description={header.subtitle} basicResources={true} instructions={header.instructions} />
+      <PageHeader
+        title={header.title}
+        description={header.subtitle}
+        basicResources={true}
+        instructions={header.instructions}
+      />
       <GetHelpSection />
       <SearchPullListSection />
       <RunListContainersSection />

--- a/src/theme/NotFound.tsx
+++ b/src/theme/NotFound.tsx
@@ -6,9 +6,9 @@ import Link from '../components/utilities/Link';
 import './styles.css';
 
 export default function NotFound(): JSX.Element {
-  const [currUrl, setCurrUrl] = useState("");
-  const [relativeUrl, setRelativeUrl] = useState("");
-  const [searchLink, setSearchLink] = useState("");
+  const [currUrl, setCurrUrl] = useState('');
+  const [relativeUrl, setRelativeUrl] = useState('');
+  const [searchLink, setSearchLink] = useState('');
 
   useEffect(() => {
     if (typeof window !== undefined) {
@@ -18,27 +18,27 @@ export default function NotFound(): JSX.Element {
 
   useEffect(() => {
     if (currUrl !== '') {
-      let splitPath = currUrl.split("/");
-      let relativePath = splitPath[splitPath.length - 1]
+      const splitPath = currUrl.split('/');
+      const relativePath = splitPath[splitPath.length - 1];
       if (relativePath !== '') {
         setRelativeUrl(relativePath);
       }
     }
-  }, [currUrl])
+  }, [currUrl]);
 
   useEffect(() => {
     if (relativeUrl !== '') {
-      setSearchLink(`https://duckduckgo.com/?t=h_&kl=us-en&kp=-1&q=podman%2F${relativeUrl}&ia=web`)
+      setSearchLink(`https://duckduckgo.com/?t=h_&kl=us-en&kp=-1&q=podman%2F${relativeUrl}&ia=web`);
     }
-  }, [relativeUrl])
+  }, [relativeUrl]);
 
   const Messages = [
     "Oh no! We can't seal the deal!",
     "We can't seal with it!",
-    "This is seal-iously embarassing...",
+    'This is seal-iously embarassing...',
     "Seal-ly us! We can't find that page.",
     "Don't flip, but we can't find that.",
-    "We don't sea that page."
+    "We don't sea that page.",
   ];
   const rand_seed = Math.floor(Math.random() * Messages.length);
 
@@ -51,36 +51,36 @@ export default function NotFound(): JSX.Element {
         })}
       />
       <Layout>
-        <main className="container margin-vert--xl">
-          <div className='img-container flex justify-center'>
+        <main className="margin-vert--xl container">
+          <div className="img-container flex justify-center">
             <img src="/images/optimized/characters/confused-seal-231w-248h.webp" alt="Not Found" />
           </div>
           <div className="row">
             <div className="col title-row-col-1">
               <h1 className="hero__title">
-                <div
-                  id="theme-NotFound-title">
-                  {Messages[rand_seed]}
-                </div>
+                <div id="theme-NotFound-title">{Messages[rand_seed]}</div>
               </h1>
               <p>
-                <div
-                  id="theme-NotFound-p1">
+                <div id="theme-NotFound-p1">
                   We could not find what you were looking for: &nbsp;
                   <Link
-                      text={currUrl}
-                      fontSize='font-bold'
-                      textColor='dark:text-white text-black'
-                      hoverColor=''
-                      underline='no-underline hover:no-underline'
-                      path='#' /> isn't a working link. <br />
-                  <span>The content may have moved; &nbsp;
+                    text={currUrl}
+                    fontSize="font-bold"
+                    textColor="dark:text-white text-black"
+                    hoverColor=""
+                    underline="no-underline hover:no-underline"
+                    path="#"
+                  />{' '}
+                  isn't a working link. <br />
+                  <span>
+                    The content may have moved; &nbsp;
                     <Link
-                      text='try a search for it'
-                      fontSize='font-bold'
-                      underline='no-underline hover:no-underline'
-                      target='_blank'
-                      path={searchLink} />
+                      text="try a search for it"
+                      fontSize="font-bold"
+                      underline="no-underline hover:no-underline"
+                      target="_blank"
+                      path={searchLink}
+                    />
                   </span>
                 </div>
               </p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5816,6 +5816,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-prettier@npm:^4.2.1":
+  version: 4.2.5
+  resolution: "eslint-plugin-prettier@npm:4.2.5"
+  dependencies:
+    prettier-linter-helpers: ^1.0.0
+  peerDependencies:
+    eslint: ">=7.28.0"
+    prettier: ">=2.0.0"
+  peerDependenciesMeta:
+    eslint-config-prettier:
+      optional: true
+  checksum: 22c29ba685f18516e3b1595e062849ccc108996a759da6067ff5d876519a5f81c8ba92c0c5623a1c62b593d417619ba44ab3b6ec1450ca753c078fd92970b883
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:5.1.1, eslint-scope@npm:^5.1.1":
   version: 5.1.1
   resolution: "eslint-scope@npm:5.1.1"
@@ -6096,6 +6111,13 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
+  languageName: node
+  linkType: hard
+
+"fast-diff@npm:^1.1.2":
+  version: 1.3.0
+  resolution: "fast-diff@npm:1.3.0"
+  checksum: d22d371b994fdc8cce9ff510d7b8dc4da70ac327bcba20df607dd5b9cae9f908f4d1028f5fe467650f058d1e7270235ae0b8230809a262b4df587a3b3aa216c3
   languageName: node
   linkType: hard
 
@@ -9695,13 +9717,14 @@ __metadata:
     clsx: ^1.2.1
     eslint: ^8.32.0
     eslint-config-prettier: ^8.6.0
+    eslint-plugin-prettier: ^4.2.1
     html-react-parser: ^3.0.16
     husky: ^8.0.3
     lint-staged: ^13.1.0
     papaparse: ^5.4.1
     postcss: ^8.5.23
     prettier: 2.8.8
-    prettier-plugin-tailwindcss: ^0.8.1
+    prettier-plugin-tailwindcss: ^0.2.8
     prism-react-renderer: ^1.3.5
     react: ^17.0.2
     react-dom: ^17.0.2
@@ -10239,61 +10262,64 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier-plugin-tailwindcss@npm:^0.8.1":
-  version: 0.8.1
-  resolution: "prettier-plugin-tailwindcss@npm:0.8.1"
+"prettier-linter-helpers@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "prettier-linter-helpers@npm:1.0.1"
+  dependencies:
+    fast-diff: ^1.1.2
+  checksum: 2dc35f5036a35f4c4f5e645887edda1436acb63687a7f12b2383e0a6f3c1f76b8a0a4709fe4d82e19157210feb5984b159bb714d43290022911ab53d606474ec
+  languageName: node
+  linkType: hard
+
+"prettier-plugin-tailwindcss@npm:^0.2.8":
+  version: 0.2.8
+  resolution: "prettier-plugin-tailwindcss@npm:0.2.8"
   peerDependencies:
     "@ianvs/prettier-plugin-sort-imports": "*"
-    "@prettier/plugin-hermes": "*"
-    "@prettier/plugin-oxc": "*"
     "@prettier/plugin-pug": "*"
     "@shopify/prettier-plugin-liquid": "*"
+    "@shufo/prettier-plugin-blade": "*"
     "@trivago/prettier-plugin-sort-imports": "*"
-    "@zackad/prettier-plugin-twig": "*"
-    prettier: ^3.0
+    prettier: ">=2.2.0"
     prettier-plugin-astro: "*"
     prettier-plugin-css-order: "*"
+    prettier-plugin-import-sort: "*"
     prettier-plugin-jsdoc: "*"
-    prettier-plugin-marko: "*"
-    prettier-plugin-multiline-arrays: "*"
     prettier-plugin-organize-attributes: "*"
     prettier-plugin-organize-imports: "*"
-    prettier-plugin-sort-imports: "*"
+    prettier-plugin-style-order: "*"
     prettier-plugin-svelte: "*"
+    prettier-plugin-twig-melody: "*"
   peerDependenciesMeta:
     "@ianvs/prettier-plugin-sort-imports":
-      optional: true
-    "@prettier/plugin-hermes":
-      optional: true
-    "@prettier/plugin-oxc":
       optional: true
     "@prettier/plugin-pug":
       optional: true
     "@shopify/prettier-plugin-liquid":
       optional: true
-    "@trivago/prettier-plugin-sort-imports":
+    "@shufo/prettier-plugin-blade":
       optional: true
-    "@zackad/prettier-plugin-twig":
+    "@trivago/prettier-plugin-sort-imports":
       optional: true
     prettier-plugin-astro:
       optional: true
     prettier-plugin-css-order:
       optional: true
+    prettier-plugin-import-sort:
+      optional: true
     prettier-plugin-jsdoc:
-      optional: true
-    prettier-plugin-marko:
-      optional: true
-    prettier-plugin-multiline-arrays:
       optional: true
     prettier-plugin-organize-attributes:
       optional: true
     prettier-plugin-organize-imports:
       optional: true
-    prettier-plugin-sort-imports:
+    prettier-plugin-style-order:
       optional: true
     prettier-plugin-svelte:
       optional: true
-  checksum: 8cfa8854b51f5660b03750e55c15257172f2a5db288039ccac8f490e28693da6830312aa3cdae9077c34160bfe753646f127199b6a8cd8897d0f20c4cc4071f2
+    prettier-plugin-twig-melody:
+      optional: true
+  checksum: 0c99295f1f47b4d35a3e19d88e6b1aac58a60479a4317fb3c3a6522b51f6b5a28cfd9c03545749354b01ca4f8ec3edf7ba2a34596c5cc58a7022b1d850bbe6be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #669

### Bug Description
Running `yarn lint` crashes completely with the error `ESLint couldn't find the plugin "eslint-plugin-prettier"`.

This happens because `.eslintrc` configures the `prettier` plugin (`"plugins": ["prettier"]` and `"prettier/prettier": ["error"]`), but `eslint-plugin-prettier` was never added to `devDependencies` in `package.json`. Additionally, `.eslintrc` contains leftover boilerplate `ignorePatterns` referencing `packages/preload/...` from an unrelated project template.

### Proposed Solution
- Add `"eslint-plugin-prettier": "^4.2.1"` to `devDependencies` in `package.json`.
- Keep `prettier` at `2.8.8` but downgrade `prettier-plugin-tailwindcss` to `^0.2.8` to maintain compatibility with Prettier 2.x and resolve the `prettier/plugins/angular` module missing error.
- Remove invalid `ignorePatterns` from `.eslintrc`.
- Verified that `yarn lint` now successfully runs across the codebase. I will submit a PR for this!

