### PR TITLE
fix(security): prevent tabnabbing by adding rel noopener noreferrer t…

### DIFF
--- a/src/components/content/ThankYouSection/index.tsx
+++ b/src/components/content/ThankYouSection/index.tsx
@@ -33,42 +33,49 @@ function ThankYouSection(): JSX.Element {
           <a
             href={redHat.href}
             target="_blank"
+            rel="noopener noreferrer"
             className="mx-4 mb-4 inline-block rounded-md p-4  dark:bg-gray-100 lg:row-span-2 lg:row-start-1 lg:mb-0">
             <img {...redHat} className="mx-auto p-4" />
           </a>
           <a
             href={amadeus.href}
             target="_blank"
+            rel="noopener noreferrer"
             className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
             <img {...amadeus} className="object-fit mx-auto max-w-sm p-4 " />
           </a>
           <a
             href={suse.href}
             target="_blank"
+            rel="noopener noreferrer"
             className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
             <img {...suse} className="object-fit mx-auto max-w-sm p-4 " />
           </a>
           <a
             href={motorola.href}
             target="_blank"
+            rel="noopener noreferrer"
             className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:row-span-2 lg:row-start-1 lg:mb-0">
             <img {...motorola} className="mx-auto p-4" />
           </a>
           <a
             href={ntt.href}
             target="_blank"
+            rel="noopener noreferrer"
             className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
             <img {...ntt} className="object-fit mx-auto max-w-sm p-4 " />
           </a>
           <a
             href={ibm.href}
             target="_blank"
+            rel="noopener noreferrer"
             className="col-span-3 mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
             <img {...ibm} className="object-fit mx-auto max-w-sm p-4 " />
           </a>
           <a
             href={debian.href}
             target="_blank"
+            rel="noopener noreferrer"
             className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:row-span-2 lg:row-start-1 lg:mb-0">
             <img {...debian} className="mx-auto p-4" />
           </a>

--- a/src/components/ui/ArticleCard/index.tsx
+++ b/src/components/ui/ArticleCard/index.tsx
@@ -53,6 +53,7 @@ function ArticleCard(props: ArticleCardProps) {
                 <a
                   href={props.path}
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="text-white no-underline hover:text-blue-100 hover:no-underline dark:text-white dark:hover:text-blue-50">
                   {sanitizeHtml(props.title)}
                 </a>
@@ -83,6 +84,7 @@ function ArticleCard(props: ArticleCardProps) {
             <a
               href={props.path}
               target="_blank"
+                  rel="noopener noreferrer"
               className="text-white no-underline hover:text-blue-100 hover:no-underline dark:text-white dark:hover:text-blue-50">
               {sanitizeHtml(props.title)}
             </a>

--- a/src/components/ui/Testimonial/index.tsx
+++ b/src/components/ui/Testimonial/index.tsx
@@ -31,7 +31,7 @@ function Testimonial(props: TestimonialProps) {
       </div>
       <div className="mt-2 mb-4 truncate">
         <p className="whitespace-normal text-gray-900 dark:text-gray-300 leading-snug mb-2">{props.description}</p>
-        {props.featuredlink && <a target="_blank" href={props.featuredlink}>{props.featuredlink}</a>}
+        {props.featuredlink && <a target="_blank" rel="noopener noreferrer" href={props.featuredlink}>{props.featuredlink}</a>}
       </div>
       <div className="mt-auto self-start text-gray-300 dark:text-gray-700 italic">
         <a href={props.path} className="text-gray-300 dark:text-gray-700 dark:hover:text-gray-700 no-underline hover:no-underline hover:bg-purple-300">


### PR DESCRIPTION
Fixes #671 

Adds `rel="noopener noreferrer"` to all anchor tags with `target="_blank"` across the UI components to prevent reverse tabnabbing security vulnerabilities.
