### PR TITLE
fix(ui): prevent Podman logo from clipping in mobile sidebar header

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -70,7 +70,9 @@
 .navbar-sidebar__brand .clean-btn {
   @apply text-gray-900 dark:text-gray-50;
 }
-
+.navbar-sidebar__brand .navbar__logo {
+  height: 3rem;
+}
 .navbar__link svg,
 .footer__item svg {
   display: inline;


### PR DESCRIPTION
## What
The Podman logo gets cut off at the top when the mobile sidebar menu is open.

## Why
The logo has a fixed height (6.25rem) that's sized for the desktop navbar,
which is stretched taller to fit it. The mobile sidebar header doesn't have
that same extra height, so the logo overflows and gets clipped.

## Fix
Added a small override so the logo scales down just inside the mobile
sidebar, without touching how it looks on desktop:

\`\`\`css
.navbar-sidebar__brand .navbar__logo {
  height: 3rem;
}
\`\`\`

## Testing
Tested locally on mobile view with the sidebar open, checked desktop still
looks the same, and checked both light and dark mode.

## Screenshots
**Before:**
<img width="369" height="354" alt="image" src="https://github.com/user-attachments/assets/0df66686-4d17-477d-9f09-de248649499f" />
**After:**
<img width="349" height="334" alt="image" src="https://github.com/user-attachments/assets/ce8907f3-04f9-48c4-a598-6f0eb6b3f02b" />