### PR TITLE
Downloads page, OS auto-detection, and broken link fixes

### DIFF
--- a/blog/2019-01-14-podman-machine-and-boot2podman.md
+++ b/blog/2019-01-14-podman-machine-and-boot2podman.md
@@ -14,11 +14,11 @@ tags: [boot2podman, podman+machine]
 
 ### Update: September 9, 2021 - Tom Sweeney
 
-This post initially discussed the boot2podman/machine project, which Anders has since deprecated. Starting with Podman v3.3, the `podman machine` command now does that same function and is part of the Podman project. Please see Brent Baude's [update](https://podman.io/blogs/2021/09/06/podman-on-macs.html) or the [podman machine](https://docs.podman.io/en/latest/machine.html) man page on [docs.podman.io](https://docs.podman.io/) for more information on how to run Podman machine. The `podman-machine` command has been deprecated.
+This post initially discussed the boot2podman/machine project, which Anders has since deprecated. Starting with Podman v3.3, the `podman machine` command now does that same function and is part of the Podman project. Please see Brent Baude's [update](/blogs/2021/09/06/podman-on-macs) or the [podman machine](https://docs.podman.io/en/latest/markdown/podman-machine.1.html) man page on [docs.podman.io](https://docs.podman.io/) for more information on how to run Podman machine. The `podman-machine` command has been deprecated.
 
 In addition, the Podman team is investigating the possibility of creating `Podman Desktop`. Please see the issue on [GitHub](https://github.com/containers/podman/issues/11494), and please add your comments or thoughts to that issue.
 
-More updates are coming, and please keep your eye on the [Podman Mailing List](https://podman.io/community/#mailing-list) and [podman.io](https://podman.io) for further information and developments.
+More updates are coming, and please keep your eye on the [Podman Mailing List](/community) and [podman.io](https://podman.io) for further information and developments.
 
 Finally, a very big thank you to Anders for his many contributions to Podman, particularly for his work in getting Podman to work smoothly on macOS.
 

--- a/blog/2019-08-14-new.md
+++ b/blog/2019-08-14-new.md
@@ -4,4 +4,4 @@ title: Podman v1.5.0 Released
 categories: [new]
 ---
 
-## [Podman has gone 1.5.0!](https://podman.io/releases/2019/08/14/podman-release-v1.5.0.html)
+## [Podman has gone 1.5.0!](/release/2019/08/14/podman-release-v1.5.0)

--- a/blog/2020-04-17-new.md
+++ b/blog/2020-04-17-new.md
@@ -4,4 +4,4 @@ title: Podman v1.9.0 Released
 categories: [new]
 ---
 
-## [Podman has gone 1.9.0!](https://podman.io/releases/2020/04/17/podman-release-v1.9.0.html)
+## [Podman has gone 1.9.0!](/release/2020/04/17/podman-release-v1.9.0)

--- a/blog/2020-08-10-podman-go-bindings.md
+++ b/blog/2020-08-10-podman-go-bindings.md
@@ -522,7 +522,7 @@ containers and pods in a way which fits very nicely in many production environme
 ## References
 
 - Podman v2 is available for most major distributions along with MacOS and Windows.
-  Installation details are available on the [Podman official website](https://podman.io/getting-started/).
+  Installation details are available on the [Podman official website](/get-started).
 
 - Documentation can be found at the [Podman Docs page](https://docs.podman.io).
   It also includes a section on the [RESTful API](https://docs.podman.io/en/latest/Reference.html).
@@ -530,7 +530,7 @@ containers and pods in a way which fits very nicely in many production environme
 ## Contribute
 
 - Any issues with the bindings can be [reported upstream](https://github.com/containers/podman/issues/new/choose).
-- Check out the [Podman community page](https://podman.io/community/) for more ways to get in touch with the community.
+- Check out the [Podman community page](/community) for more ways to get in touch with the community.
 
 ## Acknowledgments
 

--- a/blog/2020-10-05-new.md
+++ b/blog/2020-10-05-new.md
@@ -4,4 +4,4 @@ title: Podman v2.1.0 Released
 categories: [new]
 ---
 
-## [Podman has gone 2.1.0!](https://podman.io/releases/2020/10/05/podman-release-v2.1.0.html)
+## [Podman has gone 2.1.0!](/release/2020/10/05/podman-release-v2.1.0)

--- a/blog/2020-12-14-new.md
+++ b/blog/2020-12-14-new.md
@@ -4,4 +4,4 @@ title: Podman v2.2.0 Released
 categories: [new]
 ---
 
-## [Podman has gone 2.2.0!](https://podman.io/releases/2020/12/14/podman-release-v2.2.0.html)
+## [Podman has gone 2.2.0!](/release/2020/12/14/podman-release-v2.2.0)

--- a/blog/2021-02-08-easy-development-dependency-management-with-podman-and-tent.md
+++ b/blog/2021-02-08-easy-development-dependency-management-with-podman-and-tent.md
@@ -29,7 +29,7 @@ Tent is heavily inspired from [tighten/takeout](https://github.com/tighten/takeo
 ## Dependencies
 
 - Linux
-- [Podman](https://podman.io/getting-started/installation) Installed
+- [Podman](/get-started) Installed
 - Podman System Service Running
 
 If you have Podman installed, you can start the system service as follows:

--- a/blog/2021-03-02-podman-support-for-older-distros.md
+++ b/blog/2021-03-02-podman-support-for-older-distros.md
@@ -12,7 +12,7 @@ tags: [containers, podman, distro, linux, centos, ubuntu, debian]
 
 ## By Lokesh Mandvekar [GitHub](https://github.com/lsm5)
 
-The Podman Community [builds and supports packages](https://podman.io/getting-started/installation)
+The Podman Community [builds and supports packages](/get-started)
 for a wide variety of Linux distributions and operating systems. These builds are
 provided in the public Open Build Service hosted by openSUSE.
 [These pre-built packages](https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/)

--- a/blog/2021-04-02-new.md
+++ b/blog/2021-04-02-new.md
@@ -4,4 +4,4 @@ title: Podman v3.1.0 Released
 categories: [new]
 ---
 
-## [Podman has gone 3.1.0!](https://podman.io/releases/2021/04/02/podman-release-v3.1.0.html)
+## [Podman has gone 3.1.0!](/release/2021/04/02/podman-release-v3.1.0)

--- a/blog/2021-10-11-multiarch.md
+++ b/blog/2021-10-11-multiarch.md
@@ -188,4 +188,4 @@ is just a matter of practice (or some new bash scripts).
 Please also remember to pay attention to the tooling versions, as several
 bugs and deficiencies are present in earlier editions. On that same note,
 if you do encounter any strange or unexpected behavior, please reach out
-to the [upstream community for assistance](https://podman.io/community/#slack-irc-matrix-and-discord).
+to the [upstream community for assistance](/community).

--- a/blog/2022-02-22-new.md
+++ b/blog/2022-02-22-new.md
@@ -4,4 +4,4 @@ title: Podman v4.0.0 Released
 categories: [new]
 ---
 
-## [Podman has gone 4.0.0!](https://podman.io/releases/2022/02/22/podman-release-v4.0.0.html)
+## [Podman has gone 4.0.0!](/release/2022/02/22/podman-release-v4.0.0)

--- a/blog/2022-05-09-new.md
+++ b/blog/2022-05-09-new.md
@@ -4,4 +4,4 @@ title: Podman v4.1.0 Released
 categories: [new]
 ---
 
-## [Podman has gone 4.1.0!](https://podman.io/releases/2022/05/09/podman-release-v4.1.0.html)
+## [Podman has gone 4.1.0!](/release/2022/05/09/podman-release-v4.1.0)

--- a/blog/2022-08-17-new.md
+++ b/blog/2022-08-17-new.md
@@ -4,4 +4,4 @@ title: Podman v4.2.0 Released
 categories: [new]
 ---
 
-## [Podman has gone 4.2.0!](https://podman.io/releases/2022/08/17/podman-release-v4.2.0.html)
+## [Podman has gone 4.2.0!](/release/2022/08/17/podman-release-v4.2.0)

--- a/blog/2022-10-22-new.md
+++ b/blog/2022-10-22-new.md
@@ -4,4 +4,4 @@ title: Podman v4.3.0 Released
 categories: [new]
 ---
 
-## [Podman has gone 4.3.0!](https://podman.io/releases/2022/10/22/podman-release-v4.3.0.html)
+## [Podman has gone 4.3.0!](/release/2022/10/22/podman-release-v4.3.0)

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,6 @@ title: Getting Started with Podman
 
 ![Podman logo](/logos/optimized/podman-logo-orig-884w-293h.webp#gh-light-mode-only)![Podman logo](/logos/optimized/podman-logo-dark-884w-293h.webp#gh-dark-mode-only)
 
-# Getting Started with Podman
-
 Podman is a utility provided as part of the libpod library. It can be used to
 create and maintain containers. The following tutorial will teach you how to set
 up Podman and perform some basic commands.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,6 +23,7 @@ const config = {
   },
   plugins: [
     '@docusaurus/theme-live-codeblock',
+    require.resolve('./src/plugins/meetingNotesPlugin.js'),
     async function tailwindPlugin() {
       return {
         name: 'docusaurus-tailwindcss',
@@ -33,7 +34,8 @@ const config = {
         },
       };
     },
-    ['@docusaurus/plugin-content-blog',
+    [
+      '@docusaurus/plugin-content-blog',
       {
         showReadingTime: true,
         routeBasePath: 'release',
@@ -75,10 +77,15 @@ const config = {
         logo: {
           alt: 'Podman Logo',
           src: 'logos/optimized/podman-3-logo-266w-253h.webp',
+          // Docusaurus's ThemedImage hides the light-only image outright in
+          // dark mode unless a dark variant is also given — same artwork
+          // works fine on both, so just point srcDark at the same file.
+          srcDark: 'logos/optimized/podman-3-logo-266w-253h.webp',
         },
         items: [
           { to: 'features', label: 'Features', position: 'right' },
           { to: 'get-started', label: 'Get Started', position: 'right' },
+          { to: 'downloads', label: 'Downloads', position: 'right' },
           { to: 'community', label: 'Community', position: 'right' },
           {
             to: 'https://blog.podman.io',
@@ -108,16 +115,20 @@ const config = {
             title: 'Docs',
             items: [
               {
-                label: 'Installation Instructions',
-                to: 'docs/installation',
+                label: 'Downloads',
+                to: '/downloads',
+              },
+              {
+                label: 'Installation',
+                to: '/docs/installation',
               },
               {
                 label: 'Documentation',
-                to: 'docs/',
+                to: '/docs/',
               },
 
               {
-                label: 'Podman CLI Commands',
+                label: 'CLI Commands',
                 href: 'https://docs.podman.io/en/latest/Commands.html',
               },
             ],
@@ -151,19 +162,19 @@ const config = {
             title: 'Projects',
             items: [
               {
-                label: 'Podman GitHub',
+                label: 'GitHub',
                 href: 'https://github.com/podman-container-tools/podman',
               },
               {
-                label: 'Podman Desktop GitHub',
+                label: 'Desktop GitHub',
                 href: 'https://github.com/podman-desktop/podman-desktop',
               },
               {
-                label: 'Podman Website GitHub',
+                label: 'Website GitHub',
                 href: 'https://github.com/containers/podman.io',
               },
               {
-                label: 'Podman Desktop Website',
+                label: 'Desktop Website',
                 href: 'https://podman-desktop.io/',
               },
             ],

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@mdx-js/react": "^1.6.22",
     "autoprefixer": "^10.5.4",
     "clsx": "^1.2.1",
+    "gray-matter": "^4.0.3",
     "html-react-parser": "^3.0.16",
     "papaparse": "^5.4.1",
     "postcss": "^8.5.23",
@@ -44,7 +45,7 @@
     "eslint-config-prettier": "^8.6.0",
     "husky": "^8.0.3",
     "lint-staged": "^13.1.0",
-    "prettier": "2.8.8",
+    "prettier": "^3.9.6",
     "prettier-plugin-tailwindcss": "^0.8.1",
     "tailwind-scrollbar": "^3.0.0",
     "typescript": "^4.9.4"

--- a/src/components/content/BasicResourcesBox/data.ts
+++ b/src/components/content/BasicResourcesBox/data.ts
@@ -1,22 +1,22 @@
 const resources = {
-    title: 'Basic Resources',
-    buttons: [
-      {
-        text: 'Installation Instructions',
-        path: 'docs/installation',
-        icon: 'fa6-solid:book',
-      },
-      {
-        text: 'Documentation',
-        path: 'https://docs.podman.io/en/latest/',
-        icon: 'fa6-solid:book',
-      },
-      {
-        text: 'Podman Troubleshooting Guide',
-        path: 'https://github.com/containers/podman/blob/main/troubleshooting.md',
-        icon: 'fa6-solid:book',
-      },
-    ],
-  };
+  title: 'Basic Resources',
+  buttons: [
+    {
+      text: 'Installation Instructions',
+      path: '/docs/installation',
+      icon: 'fa6-solid:download',
+    },
+    {
+      text: 'Documentation',
+      path: 'https://docs.podman.io/en/latest/',
+      icon: 'fa6-solid:book',
+    },
+    {
+      text: 'Podman Troubleshooting Guide',
+      path: 'https://github.com/containers/podman/blob/main/troubleshooting.md',
+      icon: 'fa6-solid:screwdriver-wrench',
+    },
+  ],
+};
 
-  export { resources };
+export { resources };

--- a/src/components/content/BasicResourcesBox/index.tsx
+++ b/src/components/content/BasicResourcesBox/index.tsx
@@ -2,28 +2,28 @@ import React from 'react';
 import { Icon } from '@iconify/react';
 import { resources } from './data';
 
-const BasicResourcesBox = () => {
+const BasicResourcesBox = ({ showHeader = true }: { showHeader?: boolean }) => {
   return (
-    <div className="mt-4 lg:my-0">
-      <header className="container mb-6 text-center xl:mb-8 xl:text-start">
-        <h3 className="font-medium text-blue-700 dark:text-blue-500">{resources.title}</h3>
-      </header>
-      <div>
-        <ul className="mb-10 mt-4 flex flex-col gap-6 lg:mb-16 lg:mt-8 lg:gap-4 xl:flex-col">
-          {resources.buttons.map((button, index) => {
-            return (
-              <li key={index}>
-                <a
-                  href={button.path}
-                  className="no-underline hover:no-underline leading-none mx-auto flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center text-purple-700 underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:shadow-md dark:bg-gray-700 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
-                  <span className="text-left">{button.text}</span>
-                  <Icon icon={button.icon} className="order-first hidden lg:block" />
-                </a>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
+    <div className="mx-auto w-full max-w-sm rounded-xl border border-gray-100 bg-white p-6 shadow-md dark:border-gray-700 dark:bg-gray-900 lg:p-8">
+      {showHeader && (
+        <header className="mb-6 text-center">
+          <h3 className="text-2xl font-bold text-blue-700 dark:text-blue-500 lg:text-3xl">{resources.title}</h3>
+        </header>
+      )}
+      <ul className="flex flex-col gap-4">
+        {resources.buttons.map((button, index) => {
+          return (
+            <li key={index}>
+              <a
+                href={button.path}
+                className="mx-auto flex max-w-lg items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center leading-none text-purple-700 no-underline underline-offset-4 transition duration-150 ease-linear hover:-translate-y-0.5 hover:bg-purple-700 hover:text-purple-50 hover:no-underline hover:shadow-md dark:bg-gray-700 dark:text-purple-300 dark:hover:bg-purple-900 dark:hover:text-white">
+                <Icon icon={button.icon} className="shrink-0" />
+                <span className="text-left">{button.text}</span>
+              </a>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 };

--- a/src/components/content/BlogArticlesList/index.tsx
+++ b/src/components/content/BlogArticlesList/index.tsx
@@ -8,6 +8,7 @@ interface BlogArticlesListProps {
   displayCount?: number;
   altLayout?: boolean;
   title?: string;
+  description?: string;
   titleColor?: string;
   showFooter?: boolean;
   footerText?: string;
@@ -20,6 +21,7 @@ const BlogArticlesList: React.FC<BlogArticlesListProps> = ({
   displayCount,
   altLayout = false,
   title = 'Latest Articles',
+  description,
   titleColor = 'text-blue-700',
   showFooter = false,
   footerText = '',
@@ -29,16 +31,38 @@ const BlogArticlesList: React.FC<BlogArticlesListProps> = ({
   const { data, loading } = useBlogPosts(limit);
   const actualDisplayCount = displayCount ?? limit;
 
-  if (loading) {
-    return null;
-  }
-
   const containerClasses =
-    containerLayout === 'vertical' ? 'flex flex-col gap-4' : 'flex flex-wrap justify-center gap-4';
+    containerLayout === 'vertical' ? 'flex flex-col gap-4' : 'flex flex-wrap justify-center gap-6';
+
+  if (loading) {
+    return (
+      <section className={sectionClassName}>
+        <SectionHeader title={title} description={description} textColor={titleColor} />
+        <div className={containerClasses}>
+          {Array.from({ length: actualDisplayCount }).map((_, index) => (
+            <div
+              key={index}
+              className={
+                altLayout
+                  ? 'mx-auto flex w-full max-w-2xl animate-pulse flex-col overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm dark:border-white/10 dark:bg-gray-900 sm:grid sm:grid-cols-2'
+                  : 'mx-auto flex w-full max-w-sm animate-pulse flex-col overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm dark:border-white/10 dark:bg-gray-900'
+              }>
+              <div className="aspect-[16/10] w-full bg-gray-100 dark:bg-gray-700" />
+              <div className="flex flex-1 flex-col justify-center gap-2 p-5">
+                <div className="h-4 w-3/4 rounded bg-gray-100 dark:bg-gray-700" />
+                <div className="h-4 w-1/2 rounded bg-gray-100 dark:bg-gray-700" />
+                <div className="h-3 w-1/3 rounded bg-gray-100 dark:bg-gray-700" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section className={sectionClassName}>
-      <SectionHeader title={title} textColor={titleColor} />
+      <SectionHeader title={title} description={description} textColor={titleColor} />
       <div className={containerClasses}>
         {data.slice(0, actualDisplayCount).map((card, index) => (
           <ArticleCard
@@ -56,7 +80,7 @@ const BlogArticlesList: React.FC<BlogArticlesListProps> = ({
         ))}
       </div>
       {showFooter && footerText && (
-        <p className="ml-2l text-center 2xl:text-start">
+        <p className="mt-6 text-center">
           {footerText}{' '}
           <a
             href="https://blog.podman.io"

--- a/src/components/content/ColoringBookSection/data.ts
+++ b/src/components/content/ColoringBookSection/data.ts
@@ -11,11 +11,11 @@ export default {
     path: 'https://developers.redhat.com/sites/default/files/Podman%20in%20Action%20e-book%20cover_1.png',
   },
   featureImage: {
-    src: 'images/optimized/comic-cover-224w-288h.webp',
+    src: '/images/optimized/comic-cover-224w-288h.webp',
     alt: 'Container Commandos coloring book cover',
   },
   collageImages: {
-    src: 'images/optimized/coloring-pages-496w-364h.webp',
+    src: '/images/optimized/coloring-pages-496w-364h.webp',
     alt: 'A collection of pages from the Podman coloring book.',
   },
 };

--- a/src/components/content/ColoringBookSection/index.tsx
+++ b/src/components/content/ColoringBookSection/index.tsx
@@ -3,24 +3,21 @@ import Button from '@site/src/components/utilities/Button';
 import data from './data';
 function ColoringBookSection() {
   return (
-    <section className="container my-12 flex flex-wrap justify-center gap-4 lg:justify-start xl:my-20">
-      <div className="flex">
-        <div className="mx-4 flex-col items-center text-center lg:mx-0 lg:items-start lg:text-start">
-          <h2 className="my-4 p-0 font-medium text-blue-900 dark:text-blue-500">{data.title}</h2>
-          <p className="mb-4 max-w-prose lg:mb-10">{data.description}</p>
-          <Button
-            as="link"
-            outline
-            {...data.button}
-            colors="hover:bg-purple-700 dark:hover:bg-purple-900 dark:bg-purple-500 dark:text-purple-700 hover:text-white outline"
-          />
-        </div>
-        <div className="order-first mr-12 hidden lg:block">
-          <img src={data.featureImage.src} alt={data.featureImage.alt} />
+    <section className="container my-12 flex flex-col items-center gap-10 lg:flex-row lg:items-center lg:justify-between lg:gap-12 xl:my-20">
+      <div className="flex flex-col items-center gap-6 text-center sm:flex-row sm:text-start lg:items-center">
+        <img
+          src={data.featureImage.src}
+          alt={data.featureImage.alt}
+          className="w-40 shrink-0 rounded-lg shadow-lg sm:w-44 lg:w-52"
+        />
+        <div className="flex flex-col items-center sm:items-start">
+          <h2 className="mb-4 font-medium text-blue-900 dark:text-blue-500">{data.title}</h2>
+          <p className="mb-6 max-w-prose">{data.description}</p>
+          <Button as="link" outline {...data.button} />
         </div>
       </div>
-      <div className="order-first mx-auto lg:order-last xl:mx-0">
-        <img src={data.collageImages.src} alt={data.collageImages.alt} />
+      <div className="w-full max-w-sm shrink-0 lg:max-w-md">
+        <img src={data.collageImages.src} alt={data.collageImages.alt} className="w-full" />
       </div>
     </section>
   );

--- a/src/components/content/DateTimeBox/index.tsx
+++ b/src/components/content/DateTimeBox/index.tsx
@@ -1,41 +1,83 @@
 import React from 'react';
+import { Icon } from '@iconify/react';
+
+function formatTime(date: Date, timeZone: string): string {
+  return date.toLocaleString('en-US', { timeZone, hour: '2-digit', minute: '2-digit', hour12: true });
+}
+
+function formatZoneAbbreviation(date: Date, timeZone: string): string {
+  const long = Intl.DateTimeFormat('en-US', { timeZone, timeZoneName: 'long' }).format(date).split(', ')[1];
+  return long
+    .split(' ')
+    .map(word => word[0])
+    .join('');
+}
+
+type ZoneRowData = {
+  label: string;
+  flag: string;
+  time: string;
+  abbreviation: string;
+};
+
+function ZoneRow({ label, flag, time, abbreviation }: ZoneRowData): JSX.Element {
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-xl bg-white/5 px-5 py-4">
+      <div className="flex items-center gap-4">
+        <Icon icon={flag} className="h-9 w-9 shrink-0 rounded-full" />
+        <div>
+          <p className="text-sm text-purple-100">{label}</p>
+          <p className="text-2xl font-extrabold text-white">{time}</p>
+        </div>
+      </div>
+      <span className="shrink-0 rounded-md bg-purple-500 px-3 py-1.5 text-sm font-bold text-white">{abbreviation}</span>
+    </div>
+  );
+}
 
 function DateTimeBox(): JSX.Element {
   const date = new Date();
-  const centralEuropeTime = [
-    date.toLocaleString('en-US', {
-      timeZone: 'Europe/Paris',
-      hour: 'numeric',
-      minute: 'numeric',
-      hour12: false,
-    }),
-    Intl.DateTimeFormat('en-US', { timeZone: 'Europe/Paris', timeZoneName: 'long' }).format().split(',')[1],
-  ];
-  const easternTime = [
-    date.toLocaleString('en-US', {
-      timeZone: 'America/New_York',
-      hour: 'numeric',
-      minute: 'numeric',
-      hour12: false,
-    }),
-    Intl.DateTimeFormat('en-US', { timeZone: 'America/New_York', timeZoneName: 'long' }).format().split(',')[1],
+
+  const zones: ZoneRowData[] = [
+    {
+      label: 'US / Eastern Time',
+      flag: 'circle-flags:us',
+      time: formatTime(date, 'America/New_York'),
+      abbreviation: formatZoneAbbreviation(date, 'America/New_York'),
+    },
+    {
+      label: 'Europe / Central Time',
+      flag: 'circle-flags:eu',
+      time: formatTime(date, 'Europe/Paris'),
+      abbreviation: formatZoneAbbreviation(date, 'Europe/Paris'),
+    },
   ];
 
   return (
-    <article className="mb-10 max-w-lg rounded-lg bg-aqua shadow-md dark:bg-purple-900">
-      <div className="m-4 grid grid-cols-2 gap-x-4 lg:m-8">
-        <div className="col-span-full mb-5 text-center">
-          <h3 className="font-bold text-gray-300 dark:text-gray-100">Current Time</h3>
+    <article className="relative mx-auto mb-10 max-w-lg overflow-hidden rounded-2xl bg-gradient-to-br from-blue-700 via-purple-700 to-purple-900 p-6 shadow-lg lg:p-8">
+      <div className="pointer-events-none absolute -right-10 -top-10 h-40 w-40 rounded-full bg-blue-500/20 blur-3xl" />
+      <header className="relative mb-6 flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <Icon icon="mdi:earth" className="mt-0.5 h-7 w-7 shrink-0 text-purple-100" />
+          <div>
+            <h3 className="font-bold text-white">Current Time</h3>
+            <p className="text-sm text-purple-100">Community around the world</p>
+          </div>
         </div>
-        <div className="text-center">
-          <h4 className="mb-2 text-3xl font-extrabold text-purple-500 dark:text-gray-100">{centralEuropeTime[0]}</h4>
-          <p className="w-40 font-bold text-blue-900">{centralEuropeTime[1]}</p>
-        </div>
-        <div className="text-center">
-          <h4 className="mb-2 text-3xl font-extrabold text-purple-500 dark:text-gray-100">{easternTime[0]}</h4>
-          <p className="w-40 font-bold text-blue-900">{easternTime[1]}</p>
-        </div>
+        <span className="flex shrink-0 items-center gap-1.5 rounded-full bg-white/10 px-3 py-1 text-xs font-semibold text-white">
+          <span className="h-2 w-2 rounded-full bg-blue-500" />
+          Live
+        </span>
+      </header>
+      <div className="relative flex flex-col gap-4">
+        {zones.map(zone => (
+          <ZoneRow key={zone.label} {...zone} />
+        ))}
       </div>
+      <footer className="relative mt-6 flex items-center gap-2 border-t border-white/10 pt-5 text-sm text-purple-100">
+        <span className="h-2 w-2 rounded-full bg-blue-500" />
+        Most community members are online now
+      </footer>
     </article>
   );
 }

--- a/src/components/content/DownloadsGrid/index.tsx
+++ b/src/components/content/DownloadsGrid/index.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import { Icon } from '@iconify/react';
+import Button from '@site/src/components/utilities/Button';
+import operatingSystemData from '@site/src/components/layout/HeroHeader/installOptions';
+import { detectOperatingSystem, osLabels, osIcons, type OperatingSystemId } from '@site/src/lib/detectOperatingSystem';
+
+type DownloadOption = {
+  title: string;
+  subtitle: string;
+  icon: string;
+  path: string;
+};
+
+function DownloadCard({ option }: { option: DownloadOption }): JSX.Element {
+  return (
+    <div className="hover:border-purple-200 group flex items-center gap-4 rounded-xl border border-gray-100 bg-white p-5 shadow-sm transition duration-200 ease-linear hover:-translate-y-0.5 hover:shadow-lg dark:border-gray-700 dark:bg-gray-900 dark:hover:border-purple-700">
+      <span className="dark:text-purple-400 flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-purple-100 text-2xl text-purple-700 transition duration-200 ease-linear group-hover:bg-purple-700 group-hover:text-white dark:bg-purple-500/15 dark:group-hover:bg-purple-500 dark:group-hover:text-white">
+        <Icon icon={option.icon} />
+      </span>
+      <div className="flex-1">
+        <h4 className="text-gray-900 dark:text-gray-50">{option.title}</h4>
+        <p className="text-sm text-gray-500 dark:text-gray-300">{option.subtitle}</p>
+      </div>
+      <Button as="link" path={option.path} text="Download" />
+    </div>
+  );
+}
+
+function PlatformSection({
+  os,
+  highlighted = false,
+}: {
+  os: (typeof operatingSystemData)[number];
+  highlighted?: boolean;
+}): JSX.Element {
+  const options: DownloadOption[] = [os.preferred, os.alt, ...('third' in os && os.third ? [os.third] : [])];
+
+  return (
+    <section
+      className={`overflow-hidden rounded-2xl border p-6 transition duration-200 ease-linear lg:p-8 ${
+        highlighted
+          ? 'border-purple-300 bg-purple-50/50 shadow-md dark:border-purple-700 dark:bg-purple-900/10'
+          : 'border-gray-100 bg-gray-50 dark:border-gray-700 dark:bg-gray-700/25'
+      }`}>
+      <div className="mb-6 flex flex-wrap items-center gap-3">
+        <span
+          className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-2xl ${
+            highlighted
+              ? 'bg-purple-700 text-white dark:bg-purple-500'
+              : 'dark:text-purple-400 bg-white text-purple-700 shadow-sm dark:bg-gray-900'
+          }`}>
+          <Icon icon={osIcons[os.id as OperatingSystemId]} />
+        </span>
+        <h3 className="text-gray-900 dark:text-gray-50">{osLabels[os.id as OperatingSystemId]}</h3>
+        {highlighted && (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-purple-700 px-3 py-1 text-xs font-semibold text-white dark:bg-purple-500">
+            <span className="h-1.5 w-1.5 rounded-full bg-white" />
+            Recommended for your system
+          </span>
+        )}
+      </div>
+      <div className="flex flex-col gap-4">
+        {options.map((option, index) => (
+          <DownloadCard key={index} option={option} />
+        ))}
+      </div>
+      <a
+        href={os.other.path === '/downloads' ? '/docs/installation' : os.other.path}
+        className="group mt-6 inline-flex items-center gap-1.5 text-sm font-semibold text-purple-700 no-underline hover:text-purple-900 hover:no-underline dark:text-purple-500 dark:hover:text-purple-300">
+        More install options for {osLabels[os.id as OperatingSystemId]}
+        <Icon
+          icon="mdi:arrow-right"
+          className="transition-transform duration-150 ease-linear group-hover:translate-x-1"
+        />
+      </a>
+    </section>
+  );
+}
+
+function DownloadsGrid(): JSX.Element {
+  const [detectedOs, setDetectedOs] = useState<OperatingSystemId | null>(null);
+
+  useEffect(() => {
+    setDetectedOs(detectOperatingSystem());
+  }, []);
+
+  const orderedOs = detectedOs
+    ? [...operatingSystemData].sort((a, b) => (a.id === detectedOs ? -1 : b.id === detectedOs ? 1 : 0))
+    : operatingSystemData;
+
+  return (
+    <div className="container flex flex-col gap-8 pb-16 lg:pb-24">
+      {orderedOs.map(os => (
+        <PlatformSection key={os.id} os={os} highlighted={os.id === detectedOs} />
+      ))}
+    </div>
+  );
+}
+
+export default DownloadsGrid;

--- a/src/components/content/FeaturesCarousel/data.ts
+++ b/src/components/content/FeaturesCarousel/data.ts
@@ -5,10 +5,19 @@ const tabData = [
     commands: ['podman search', 'podman pull'],
     description:
       'Find and pull down containers whether they are on dockerhub.io or quay.io, an internal registry server, or direct from a vendor.',
-    image: {
-      src: 'images/optimized/cli-screens/cli-find-image.webp',
-      alt: 'example of podman commands',
-    },
+    terminal: `$ podman search busybox
+INDEX       NAME                               DESCRIPTION              STARS  OFFICIAL  AUTOMATED
+docker.io   docker.io/library/busybox          Busybox base image.      1882   [OK]
+docker.io   docker.io/radial/busyboxplus       Full-chain, Internet...  30               [OK]
+docker.io   docker.io/yauritux/busybox-curl    Busybox with CURL        8
+...
+
+$ podman pull docker.io/library/busybox
+Trying to pull docker.io/library/busybox:latest...
+Getting image source signatures
+Copying blob 5b8c72934dfc done
+Writing manifest to image destination
+Storing signatures`,
   },
   {
     label: 'Run',
@@ -16,10 +25,12 @@ const tabData = [
     commands: ['podman run'],
     description:
       'Run containers using images pulled from a registry, or from images you build yourself. Podman lets you run containers as a regular user or as root.',
-    image: {
-      src: 'images/optimized/cli-screens/cli-run-image.webp',
-      alt: 'example of podman commands',
-    },
+    terminal: `$ podman run -dt -p 8080:80/tcp docker.io/library/httpd
+b2e4a1c9f3d8
+
+$ podman ps
+CONTAINER ID  IMAGE                           COMMAND           CREATED         STATUS         PORTS                  NAMES
+b2e4a1c9f3d8  docker.io/library/httpd:latest  httpd-foreground  10 seconds ago  Up 10 seconds  0.0.0.0:8080->80/tcp  eager_almeida`,
   },
   {
     label: 'Build',
@@ -27,10 +38,17 @@ const tabData = [
     commands: ['podman build'],
     description:
       'Build OCI and Docker-compatible container images using a Containerfile or Dockerfile — no daemon required.',
-    image: {
-      src: 'images/optimized/cli-screens/cli-build-image.webp',
-      alt: 'example of podman commands',
-    },
+    terminal: `$ podman build -t myapp .
+STEP 1/4: FROM registry.access.redhat.com/ubi9/ubi-minimal
+STEP 2/4: COPY . /app
+STEP 3/4: WORKDIR /app
+STEP 4/4: CMD ["./start.sh"]
+COMMIT myapp
+Successfully tagged localhost/myapp:latest
+
+$ podman images
+REPOSITORY        TAG      IMAGE ID      CREATED        SIZE
+localhost/myapp   latest   4f9a2b1c8e3d  5 seconds ago  112 MB`,
   },
   {
     label: 'Share',
@@ -38,10 +56,16 @@ const tabData = [
     commands: ['podman push'],
     description:
       'Podman lets you push your newly-built containers anywhere you want with a single podman push command.',
-    image: {
-      src: 'images/optimized/cli-screens/cli-share-image.webp',
-      alt: 'example of podman commands',
-    },
+    terminal: `$ podman push myapp quay.io/myuser/myapp
+Getting image source signatures
+Copying blob 8a3f0c9b1e2d done
+Copying blob 1c92e4a7b6f0 done
+Writing manifest to image destination
+Storing signatures
+
+$ podman search quay.io/myuser/myapp
+INDEX     NAME                    DESCRIPTION  STARS  OFFICIAL
+quay.io   quay.io/myuser/myapp                  0`,
   },
 ];
 

--- a/src/components/content/FeaturesCarousel/index.tsx
+++ b/src/components/content/FeaturesCarousel/index.tsx
@@ -1,60 +1,51 @@
 import React, { useState } from 'react';
 import { Icon } from '@iconify/react';
+import TerminalCard from '@site/src/components/utilities/TerminalCard';
 import tabData from './data';
 
+const tabIcons: Record<string, string> = {
+  Find: 'mdi:magnify',
+  Run: 'mdi:play-circle-outline',
+  Build: 'mdi:hammer-wrench',
+  Share: 'mdi:share-variant-outline',
+};
+
 const Tab = (props): JSX.Element => {
-  const { label, commands, method, isActive } = props;
+  const { label, method, isActive } = props;
   return (
     <button
       onClick={method}
-      className={`rounded-lg p-4 shadow-sm transition duration-150 hover:bg-purple-700 hover:text-white dark:hover:bg-purple-900 dark:hover:text-gray-50 md:h-36 md:w-56
-      ${
+      className={`flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-semibold shadow-sm transition duration-150 ease-linear ${
         isActive
-          ? 'bg-gradient-radial from-purple-500 to-purple-700 text-white dark:from-purple-700 dark:to-purple-900 dark:shadow-purple-900'
-          : '0 bg-white text-gray-700 dark:bg-gray-700 dark:text-gray-300 dark:shadow-gray-700'
+          ? 'bg-gradient-to-br from-purple-500 to-purple-700 text-white dark:from-purple-700 dark:to-purple-900'
+          : 'bg-white text-gray-700 hover:bg-purple-50 hover:text-purple-700 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-500 dark:hover:text-white'
       }`}>
-      <h4 className="text-blue-500 dark:text-blue-500">{label}</h4>
-      <ul>
-        {commands.map((command, index) => {
-          return (
-            <li key={index} className="hidden font-mono text-sm md:block">
-              {command}
-            </li>
-          );
-        })}
-      </ul>
+      <Icon icon={tabIcons[label]} className="text-base" />
+      {label}
     </button>
   );
 };
 const TabContent = (props): JSX.Element => {
-  const { title, commands, image, description, isActive } = props;
+  const { title, commands, terminal, description, isActive } = props;
   return (
     <>
-      <div className="xl:my-23 container my-12 flex flex-wrap justify-center gap-4 md:gap-12">
+      <div className="mx-auto my-16 flex w-full max-w-6xl flex-wrap items-center justify-center gap-8 px-4">
         <div className="max-w-sm">
-          <h3
-            className={`text-3xl ${
-              isActive % 2 === 0
-                ? 'text-white dark:text-white'
-                : isActive === 1
-                ? 'text-blue-700 dark:text-purple-500'
-                : 'text-purple-700 dark:text-purple-500'
-            }`}>
-            {title}
-          </h3>
-          <ul className="my-4 lg:my-12">
+          <h3 className="text-3xl text-white dark:text-white">{title}</h3>
+          <ul className="my-6 flex flex-col gap-2">
             {commands.map((command, index) => (
-              <li key={index} className={`font-mono  ${isActive == 2 ? 'text-white' : 'text-blue-500'}`}>
+              <li
+                key={index}
+                className="inline-flex w-fit items-center gap-1.5 rounded-md bg-white/10 px-3 py-1.5 font-mono text-sm text-blue-100 ring-1 ring-white/15">
+                <Icon icon="mdi:chevron-right" className="shrink-0 text-xs text-purple-300" />
                 {command}
               </li>
             ))}
           </ul>
-          <p className={isActive % 2 === 0 ? 'text-white dark:text-white' : 'text-gray-900 dark:text-white'}>
-            {description}
-          </p>
+          <p className="text-white/90 dark:text-white/90">{description}</p>
         </div>
-        <div className={`${isActive % 2 === 1 && 'md:order-first'}`}>
-          <img {...image} className="object-fit lg:w-[600px]" />
+        <div className={`w-full max-w-[500px] ${isActive % 2 === 1 && 'md:order-first'}`}>
+          <TerminalCard>{terminal}</TerminalCard>
         </div>
       </div>
     </>
@@ -67,7 +58,7 @@ function FeaturesCarousel() {
   // render content
   return (
     <section className="bg-gray-100 dark:bg-gray-900">
-      <div className="container -mb-6 flex justify-center gap-5 md:-mb-10 md:gap-8">
+      <div className="relative z-10 mx-auto -mb-8 flex w-full max-w-3xl flex-wrap justify-center gap-3 px-4">
         {/* Loop through Tab data and generate tab buttons for each */}
         {tabData.map((tab, index) => {
           return (
@@ -75,36 +66,27 @@ function FeaturesCarousel() {
           );
         })}
       </div>
-      <section
-        className={`py-10 md:py-16 ${
-          activeTabIndex % 2 === 1
-            ? 'bg-white dark:bg-gray-900 dark:bg-gradient-to-b dark:from-purple-900 dark:to-purple-900/50'
-            : activeTabIndex === 2
-            ? 'bg-gradient-to-br from-blue-300 via-blue-500 to-blue-900 dark:from-blue-900 dark:to-gray-700/50'
-            : 'bg-gradient-to-br from-purple-300 via-purple-700 to-purple-900'
-        }`}>
-        <div className="space-between container flex">
+      <section className="bg-gradient-to-br from-purple-300 via-purple-700 to-purple-900 py-10 dark:from-purple-900 dark:via-purple-900 dark:to-gray-900 md:py-16">
+        <div className="mx-auto flex min-h-[540px] w-full max-w-6xl items-center justify-between px-4">
           <button
             type="button"
+            className="shrink-0"
             onClick={() => setActiveTabIndex(activeTabIndex > 0 ? activeTabIndex - 1 : tabData.length - 1)}
             aria-label="Previous feature">
             <Icon
               icon="fa-solid:arrow-circle-left"
-              className={`text-3xl transition duration-150 ease-linear hover:opacity-50 dark:hover:opacity-50  ${
-                activeTabIndex % 2 === 0 ? 'text-white' : 'text-purple-700 dark:text-gray-50'
-              }`}
+              className="text-3xl text-white transition duration-150 ease-linear hover:opacity-50 dark:hover:opacity-50"
             />
           </button>
           <TabContent {...tabData[activeTabIndex]} isActive={activeTabIndex} />
           <button
             type="button"
+            className="shrink-0"
             onClick={() => setActiveTabIndex(activeTabIndex < 3 ? activeTabIndex + 1 : 0)}
             aria-label="Next feature">
             <Icon
               icon="fa-solid:arrow-circle-right"
-              className={`text-3xl transition duration-150 ease-linear hover:text-purple-900 dark:hover:text-purple-700 ${
-                activeTabIndex % 2 === 0 ? 'text-white' : 'text-gray-700 dark:text-gray-50'
-              }`}
+              className="text-3xl text-white transition duration-150 ease-linear hover:opacity-50 dark:hover:opacity-50"
             />
           </button>
         </div>

--- a/src/components/content/TestimonialSection/index.tsx
+++ b/src/components/content/TestimonialSection/index.tsx
@@ -14,39 +14,40 @@ function TestimonialSection() {
     slider.scrollLeft = slider.scrollLeft + 500;
   };
   return (
-    <section className="bg-gradient-to-b from-white to-purple-100 dark:from-gray-900 dark:via-gray-900 dark:to-purple-900">
+    <section className="relative overflow-hidden bg-gradient-to-b from-white to-purple-100 dark:from-gray-900 dark:via-gray-900 dark:to-purple-900">
+      <div className="pointer-events-none absolute -top-24 left-1/2 h-72 w-[36rem] -translate-x-1/2 rounded-full bg-blue-300/20 blur-3xl dark:bg-purple-700/10" />
+      <div className="pointer-events-none absolute bottom-0 right-0 h-72 w-72 translate-x-1/3 translate-y-1/3 rounded-full bg-purple-300/20 blur-3xl dark:bg-blue-700/10" />
       <SectionHeader
         title="What people are saying about Podman"
+        description="Real feedback from developers, contributors, and companies building with Podman every day."
         textGradient={true}
         textGradientStops="from-blue-700 to-blue-500"
       />
-      <div className="container relative mx-auto my-8 flex items-center justify-center">
+      <div className="container relative mx-auto my-8 flex items-center justify-center gap-3">
         <button
           type="button"
           onClick={slideLeft}
-          className="hidden sm:block xl:hidden"
-          aria-label="Previous testimonial">
-          <Icon
-            icon="fa-solid:arrow-circle-left"
-            className="text-4xl text-gray-500 opacity-25 transition duration-150 ease-linear hover:text-purple-900 hover:opacity-100 dark:hover:text-purple-700"
-          />
+          aria-label="Previous testimonial"
+          className="hidden shrink-0 items-center justify-center rounded-full border border-white/60 bg-white/70 p-3 text-purple-700 shadow-md backdrop-blur transition duration-200 ease-out hover:-translate-y-0.5 hover:bg-white hover:shadow-lg dark:border-white/10 dark:bg-gray-700/70 dark:text-purple-300 dark:hover:bg-gray-700 sm:flex">
+          <Icon icon="mdi:chevron-left" className="text-2xl" />
         </button>
-        <div
-          id="slider"
-          className="mx-auto flex h-full w-full justify-center overflow-x-scroll scroll-smooth whitespace-nowrap scrollbar">
-          {testimonials.map((testimonial, index) => {
-            return <Testimonial key={index} {...testimonial} />;
-          })}
+        <div className="relative w-full overflow-hidden">
+          <div
+            id="slider"
+            className="flex h-full w-full snap-x snap-mandatory justify-start gap-2 overflow-x-scroll scroll-smooth py-2 scrollbar">
+            {testimonials.map((testimonial, index) => {
+              return <Testimonial key={index} {...testimonial} />;
+            })}
+          </div>
+          <div className="pointer-events-none absolute inset-y-0 left-0 w-12 bg-gradient-to-r from-white to-transparent dark:from-gray-900" />
+          <div className="pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-l from-purple-100 to-transparent dark:from-purple-900" />
         </div>
         <button
           type="button"
           onClick={slideRight}
-          className="hidden sm:block xl:hidden"
-          aria-label="Next testimonial">
-          <Icon
-            icon="fa-solid:arrow-circle-right"
-            className="dark:hover-text-purple-700 text-4xl text-gray-500 opacity-25 transition duration-150 ease-linear hover:text-purple-900 hover:opacity-100"
-          />
+          aria-label="Next testimonial"
+          className="hidden shrink-0 items-center justify-center rounded-full border border-white/60 bg-white/70 p-3 text-purple-700 shadow-md backdrop-blur transition duration-200 ease-out hover:-translate-y-0.5 hover:bg-white hover:shadow-lg dark:border-white/10 dark:bg-gray-700/70 dark:text-purple-300 dark:hover:bg-gray-700 sm:flex">
+          <Icon icon="mdi:chevron-right" className="text-2xl" />
         </button>
       </div>
     </section>

--- a/src/components/content/ThankYouSection/data.ts
+++ b/src/components/content/ThankYouSection/data.ts
@@ -2,43 +2,43 @@ const sponsorData = [
   {
     label: 'Red Hat',
     href: 'https://www.redhat.com/',
-    src: 'logos/optimized/red-hat-120w-77h.webp',
+    src: '/logos/optimized/red-hat-120w-77h.webp',
     alt: 'Red Hat Logo',
   },
-   {
+  {
     label: 'Amadeus',
     href: 'https://www.amadeus.com/',
-    src: 'logos/optimized/amadeus-171w-22h.webp',
+    src: '/logos/optimized/amadeus-171w-22h.webp',
     alt: 'Amadeus Logo',
   },
   {
     label: 'Suse',
     href: 'https://www.suse.com',
-    src: 'logos/optimized/suse-167w-30h.webp',
+    src: '/logos/optimized/suse-167w-30h.webp',
     alt: 'Suse Logo',
   },
   {
     label: 'Motorola',
     href: 'https://www.motorolasolutions.com/',
-    src: 'logos/optimized/motorola-solutions-128w-110h.webp',
+    src: '/logos/optimized/motorola-solutions-128w-110h.webp',
     alt: 'Motorola Solutions Logo',
   },
   {
     label: 'NTT',
     href: 'https://www.global.ntt',
-    src: 'logos/optimized/ntt-145w-50h.webp',
+    src: '/logos/optimized/ntt-145w-50h.webp',
     alt: 'NTT Logo',
   },
   {
     label: 'IBM',
     href: 'https://www.ibm.com',
-    src: 'logos/optimized/ibm-92w-37h.webp',
+    src: '/logos/optimized/ibm-92w-37h.webp',
     alt: 'IBM Logo',
   },
   {
     label: 'Debian',
     href: 'https://www.debian.org/',
-    src: 'logos/optimized/debian-68w-90h.webp',
+    src: '/logos/optimized/debian-68w-90h.webp',
     alt: 'Debian Logo',
   },
 ];

--- a/src/components/content/ThankYouSection/index.tsx
+++ b/src/components/content/ThankYouSection/index.tsx
@@ -1,84 +1,27 @@
 import React from 'react';
 import sponsorData from './data';
-import { Icon } from '@iconify/react';
 
 function ThankYouSection(): JSX.Element {
-  const [redHat, amadeus, suse, motorola, ntt, ibm, debian] = sponsorData;
-  const slideLeft = () => {
-    const slider = document.getElementById('slider');
-    slider.scrollLeft = slider.scrollLeft - 500;
-  };
-  const slideRight = () => {
-    const slider = document.getElementById('slider');
-    slider.scrollLeft = slider.scrollLeft + 500;
-  };
   return (
     <section className="my-8 lg:my-12">
       <header className="container my-4 text-center lg:my-8">
         <h2 className="mb-3 text-blue-700 dark:text-purple-500">Special thanks to our contributors</h2>
-        <p className="text-gray-900">
+        <p className="text-gray-900 dark:text-gray-100">
           The Podman community has contributors from many different organizations, including:
         </p>
       </header>
-      <div className="relative mx-auto my-8 flex items-center">
-        <button type="button" onClick={slideLeft} className="lg:hidden" aria-label="Previous contributor">
-          <Icon
-            icon="fa-solid:arrow-circle-left"
-            className="text-4xl text-gray-500 opacity-25 transition duration-150 ease-linear hover:text-purple-900 hover:opacity-100 dark:hover:text-purple-700"
-          />
-        </button>
-        <div
-          id="slider"
-          className="justify-center mx-auto h-full w-full  place-items-center gap-6 overflow-x-scroll scroll-smooth whitespace-nowrap scrollbar scrollbar-track-purple-500 lg:container lg:grid">
+      <div className="container flex flex-wrap items-center justify-center gap-x-10 gap-y-8 lg:gap-x-14">
+        {sponsorData.map(sponsor => (
           <a
-            href={redHat.href}
+            key={sponsor.label}
+            href={sponsor.href}
             target="_blank"
-            className="mx-4 mb-4 inline-block rounded-md p-4  dark:bg-gray-100 lg:row-span-2 lg:row-start-1 lg:mb-0">
-            <img {...redHat} className="mx-auto p-4" />
+            rel="noopener noreferrer"
+            aria-label={sponsor.label}
+            className="flex h-16 w-32 shrink-0 items-center justify-center rounded-md transition duration-150 ease-linear hover:-translate-y-1 hover:bg-gray-50 hover:shadow-md dark:bg-white dark:hover:shadow-lg">
+            <img {...sponsor} className="max-h-12 max-w-[80%] object-contain" />
           </a>
-          <a
-            href={amadeus.href}
-            target="_blank"
-            className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
-            <img {...amadeus} className="object-fit mx-auto max-w-sm p-4 " />
-          </a>
-          <a
-            href={suse.href}
-            target="_blank"
-            className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
-            <img {...suse} className="object-fit mx-auto max-w-sm p-4 " />
-          </a>
-          <a
-            href={motorola.href}
-            target="_blank"
-            className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:row-span-2 lg:row-start-1 lg:mb-0">
-            <img {...motorola} className="mx-auto p-4" />
-          </a>
-          <a
-            href={ntt.href}
-            target="_blank"
-            className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
-            <img {...ntt} className="object-fit mx-auto max-w-sm p-4 " />
-          </a>
-          <a
-            href={ibm.href}
-            target="_blank"
-            className="col-span-3 mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
-            <img {...ibm} className="object-fit mx-auto max-w-sm p-4 " />
-          </a>
-          <a
-            href={debian.href}
-            target="_blank"
-            className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:row-span-2 lg:row-start-1 lg:mb-0">
-            <img {...debian} className="mx-auto p-4" />
-          </a>
-        </div>
-        <button type="button" onClick={slideRight} className="lg:hidden" aria-label="Next contributor">
-          <Icon
-            icon="fa-solid:arrow-circle-right"
-            className="dark:hover-text-purple-700 text-4xl text-gray-500 opacity-25 transition duration-150 ease-linear hover:text-purple-900 hover:opacity-100"
-          />
-        </button>
+        ))}
       </div>
     </section>
   );

--- a/src/components/content/ThankYouSection/index.tsx
+++ b/src/components/content/ThankYouSection/index.tsx
@@ -3,25 +3,27 @@ import sponsorData from './data';
 
 function ThankYouSection(): JSX.Element {
   return (
-    <section className="my-8 lg:my-12">
-      <header className="container my-4 text-center lg:my-8">
-        <h2 className="mb-3 text-blue-700 dark:text-purple-500">Special thanks to our contributors</h2>
-        <p className="text-gray-900 dark:text-gray-100">
-          The Podman community has contributors from many different organizations, including:
-        </p>
-      </header>
-      <div className="container flex flex-wrap items-center justify-center gap-x-10 gap-y-8 lg:gap-x-14">
-        {sponsorData.map(sponsor => (
-          <a
-            key={sponsor.label}
-            href={sponsor.href}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={sponsor.label}
-            className="flex h-16 w-32 shrink-0 items-center justify-center rounded-md transition duration-150 ease-linear hover:-translate-y-1 hover:bg-gray-50 hover:shadow-md dark:bg-white dark:hover:shadow-lg">
-            <img {...sponsor} className="max-h-12 max-w-[80%] object-contain" />
-          </a>
-        ))}
+    <section className="pb-16 pt-8 lg:pb-24 lg:pt-12">
+      <div className="container">
+        <header className="mx-auto mb-10 max-w-2xl text-center lg:mb-12">
+          <h2 className="mb-3 text-blue-700 dark:text-purple-500">Special thanks to our contributors</h2>
+          <p className="text-gray-900 dark:text-gray-100">
+            The Podman community has contributors from many different organizations, including:
+          </p>
+        </header>
+        <div className="mx-auto flex max-w-4xl flex-wrap items-center justify-center gap-x-10 gap-y-8 rounded-2xl border border-gray-100 bg-gray-50 px-8 py-10 dark:border-gray-700 dark:bg-gray-700/25 lg:gap-x-14 lg:px-14">
+          {sponsorData.map(sponsor => (
+            <a
+              key={sponsor.label}
+              href={sponsor.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={sponsor.label}
+              className="flex h-16 w-32 shrink-0 items-center justify-center rounded-md bg-white shadow-sm transition duration-150 ease-linear hover:-translate-y-1 hover:shadow-md dark:bg-white">
+              <img {...sponsor} className="max-h-12 max-w-[80%] object-contain" />
+            </a>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/src/components/content/WelcomeBanner/index.tsx
+++ b/src/components/content/WelcomeBanner/index.tsx
@@ -5,21 +5,21 @@ function WelcomeBanner() {
   return (
     <section className="bg-gray-900">
       <div className="container my-20 grid grid-cols-4 place-items-center gap-y-4 md:grid-cols-10 lg:grid-cols-12">
-        <div className=" col-span-2 hidden md:block lg:row-span-2">
+        <div className="col-span-2 hidden md:block lg:row-span-2">
           <Icon icon="noto-v1:confetti-ball" className="rotate-[120deg] text-7xl" />
         </div>
-        <header className=" col-span-full flex items-center gap-4 text-center md:col-span-6 lg:col-span-8">
-          <h2 className="bg-gradient-to-r from-purple-500 to-blue-500 bg-clip-text text-5xl font-extrabold text-transparent dark:bg-gradient-to-r  dark:from-purple-700 dark:to-blue-700 dark:bg-clip-text dark:text-transparent">
+        <header className="col-span-full flex items-center gap-4 text-center md:col-span-6 lg:col-span-8">
+          <h2 className="bg-gradient-to-r from-purple-500 to-blue-500 bg-clip-text text-5xl font-extrabold text-transparent dark:bg-gradient-to-r dark:from-purple-700 dark:to-blue-700 dark:bg-clip-text dark:text-transparent">
             Welcome to the new Podman Website!
           </h2>
         </header>
         <div className="col-span-2 hidden md:block lg:row-span-2">
           <Icon icon="noto-v1:confetti-ball" className="rotate-180 text-7xl" />
         </div>
-        <div className="col-span-full mt-8 flex flex-wrap items-center gap-8 md:mt-0 lg:col-span-8 ">
+        <div className="col-span-full mt-8 flex flex-wrap items-center gap-8 md:mt-0 lg:col-span-8">
           <p className="max-w-prose text-center text-white">
-            Take a look around, don't forget to check out the new <a href="docs">docs layout</a>. Please report
-            any bugs to <a href="https://github.com/containers/website-new/issues">the issue tracker</a>.
+            Take a look around, don't forget to check out the new <a href="/docs">docs layout</a>. Please report any
+            bugs to <a href="https://github.com/containers/website-new/issues">the issue tracker</a>.
           </p>
         </div>
       </div>

--- a/src/components/layout/CommunityMeetingsCardGrid/index.tsx
+++ b/src/components/layout/CommunityMeetingsCardGrid/index.tsx
@@ -1,10 +1,11 @@
-import React, { ReactNode, useEffect, useRef, useState } from 'react';
+import React, { ReactNode, useRef, useState } from 'react';
+import { Icon } from '@iconify/react';
+import { usePluginData } from '@docusaurus/useGlobalData';
 import CustomCard from '@site/src/components/ui/CustomCard';
 import SubcardGrid from '@site/src/components/layout/SubcardGrid';
-import SectionHeader from '@site/src/components/layout/SectionHeader';
 import Dropdown from '@site/src/components/utilities/DropDown';
 import CloseIcon from '@site/src/components/shapes/CloseIcon';
-import * as markDownFiles from '@site/static/data/meetings/notes/index'; // ToDo: Lazy load these files
+import VideoEmbed from '@site/src/components/ui/VideoEmbed';
 
 import './styles.css';
 
@@ -13,44 +14,73 @@ type CommunityMeetingsCardProps = {
   subtitle: string;
   date: string;
   timeZone: string;
-  buttons: [
-    {
-      text: string;
-      path: string;
-    },
-  ];
+  buttons: { text: string; path: string }[];
+};
+
+type MeetingNote = {
+  slug: string;
+  displayDate: string;
+  title: string;
+  recordingLink?: string;
+  recordingEmbedUrl?: string;
+};
+
+type MeetingsData = { community: MeetingNote[]; cabal: MeetingNote[] };
+
+type ModalTriggerContent = {
+  text: string;
+  markDown?: ReactNode;
+  embedUrl?: string;
+  modalHeaderData?: string;
+  icon?: string;
 };
 
 type DropdownOptionProps = {
   date: string;
-  meeting_recording: {
-    text: string;
-    link: string;
-  };
-  meeting_minutes: {
-    text: string;
-    markDown: ReactNode;
-    modalHeaderData?: string;
-  };
+  meeting_recording: ModalTriggerContent & { link?: string };
+  meeting_minutes: ModalTriggerContent & { path: string };
 };
 
 type SubcardButtonProps = {
   text: string;
   path?: string;
   markDown?: ReactNode;
-  modalHeaderData?: String;
+  embedUrl?: string;
+  modalHeaderData?: string;
+  icon?: string;
 };
 
 type SubcardGridProps = {
   buttons: SubcardButtonProps[];
   icon: string;
   date: string;
+  embedUrl?: string;
+  embedTitle?: string;
 };
 
-function toggleModalOpen(ref, handler) {
-  useEffect(() => {
-    const listener = event => {
-      if (ref?.current?.contains(event.target)) {
+function toModalOption(note: MeetingNote): DropdownOptionProps {
+  return {
+    date: note.displayDate,
+    meeting_minutes: {
+      path: `/community/meetings/${note.slug}`,
+      modalHeaderData: note.title,
+      text: 'Meeting Minutes',
+      icon: 'mdi:text-box-outline',
+    },
+    meeting_recording: {
+      link: note.recordingLink,
+      embedUrl: note.recordingEmbedUrl,
+      modalHeaderData: note.title,
+      text: 'Watch Recording',
+      icon: 'mdi:play-circle-outline',
+    },
+  };
+}
+
+function useOutsideClick(ref: React.RefObject<HTMLElement>, handler: (event: Event) => void) {
+  React.useEffect(() => {
+    const listener = (event: Event) => {
+      if (ref?.current?.contains(event.target as Node)) {
         return;
       }
       handler(event);
@@ -64,73 +94,45 @@ function toggleModalOpen(ref, handler) {
   }, [ref, handler]);
 }
 
-function CommunityMeetingsCardGrid({ cards }) {
-  let cabalDropdownOptions: DropdownOptionProps[] = [];
-  let MeetingDropdownOptions: DropdownOptionProps[] = [];
-
+function CommunityMeetingsCardGrid({ cards }: { cards: CommunityMeetingsCardProps[] }) {
+  const meetings = usePluginData('meeting-notes-plugin') as MeetingsData;
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalHeader, setModalHeader] = useState<ReactNode | undefined>(undefined);
-  const [meetinNotesMD, setMeetinNotesMD] = useState<ReactNode | undefined>(undefined);
-  const meetingMinutesRef = [useRef(), useRef()];
-  const modalRef = useRef();
+  const [modalContent, setModalContent] = useState<ReactNode | undefined>(undefined);
+  const meetingMinutesRef = [useRef<HTMLDivElement>(null), useRef<HTMLDivElement>(null)];
+  const modalRef = useRef<HTMLDialogElement>(null);
 
-  toggleModalOpen(modalRef, () => setIsModalOpen(false));
+  useOutsideClick(modalRef, () => setIsModalOpen(false));
+
+  const communityOptions = meetings.community.map(toModalOption);
+  const cabalOptions = meetings.cabal.map(toModalOption);
 
   const prepareModalHeader = (text: string, date: string) => {
-    const modalHeader: ReactNode = (
-      <div className="modal-header dark:bg-gray-500 dark:shadow-none">
-        <h3 className="modal-header-title dark:text-gray-900">{text}</h3>
-        <h3 className="modal-header-date dark:text-gray-900">{date}</h3>
-        <div className="cursor-pointer" onClick={() => setIsModalOpen(false)}>
-          <CloseIcon />
+    setModalHeader(
+      <div className="flex items-center justify-between gap-4 rounded-t-2xl border-b border-gray-100 bg-white px-6 py-4 dark:border-gray-700 dark:bg-gray-700">
+        <div>
+          <h3 className="text-gray-900 dark:text-gray-50">{text}</h3>
+          <h3 className="text-sm font-normal text-gray-500 dark:text-gray-300">{date}</h3>
         </div>
-      </div>
+        <button
+          type="button"
+          aria-label="Close"
+          className="shrink-0 cursor-pointer rounded-full p-1 text-gray-500 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-500 dark:hover:text-gray-50"
+          onClick={() => setIsModalOpen(false)}>
+          <CloseIcon />
+        </button>
+      </div>,
     );
-    setModalHeader(modalHeader);
   };
 
-  const populateMeetings = (): void => {
-    Object.values(markDownFiles)?.forEach(mdFile => {
-      let mdReader = mdFile?.default(useRef());
-      mdReader?.props?.children?.forEach(child => {
-        let field1: string = child?.props?.children?.[0];
-        let field2: object = child?.props?.children?.[1];
-        if (typeof field1 == 'string' && (field1.includes('BlueJeans') || field1.includes('Video'))) {
-          if (mdFile?.contentTitle?.includes('Cabal')) {
-            cabalDropdownOptions.unshift({
-              date: (mdFile?.toc?.[0]?.value as string).split(/[0-9]{2}:[0-9]{2}/)[0],
-              meeting_minutes: {
-                markDown: mdReader,
-                modalHeaderData: mdFile['contentTitle'],
-                text: 'Meeting Minutes',
-              },
-              meeting_recording: {
-                link: field2?.props?.href,
-                text: 'Watch Recording',
-              },
-            });
-          } else {
-            MeetingDropdownOptions.unshift({
-              date: (mdFile?.toc?.[0]?.value as string).split(/[0-9]{2}:[0-9]{2}/)[0],
-              meeting_minutes: {
-                markDown: mdReader,
-                modalHeaderData: mdFile['contentTitle'],
-                text: 'Meeting Minutes',
-              },
-              meeting_recording: {
-                link: field2?.props?.href,
-                text: 'Watch Recording',
-              },
-            });
-          }
-        }
-      });
-    });
-  };
-
-  const toggleIsModalOpen = (...modalData) => {
-    modalData && setMeetinNotesMD(modalData[0].markDown);
-    prepareModalHeader(modalData[0].modalHeaderData, modalData[1]);
+  const toggleIsModalOpen = (content: ModalTriggerContent, date: string) => {
+    const title = content?.modalHeaderData ?? '';
+    if (content?.embedUrl) {
+      setModalContent(<VideoEmbed url={content.embedUrl} title={title} className="mx-auto max-w-3xl" />);
+    } else {
+      setModalContent(content?.markDown);
+    }
+    prepareModalHeader(title, date);
     setIsModalOpen(true);
   };
 
@@ -138,67 +140,71 @@ function CommunityMeetingsCardGrid({ cards }) {
     const { meeting_minutes, meeting_recording, date } = props;
 
     return (
-      <div className="inline-flex justify-around bg-white px-8 py-1 dark:bg-gray-700 dark:shadow-none">
-        <h3 className="flex-1 pl-1 text-base text-gray-700 dark:text-gray-50">{date}</h3>
-        <a className="flex-1 no-underline hover:no-underline" href={meeting_recording?.link}>
-          {meeting_recording?.text}
-        </a>
-        <a
-          onClick={() => {
-            toggleIsModalOpen(meeting_minutes, date);
-          }}
-          className="cursor-pointer">
-          {meeting_minutes?.text}
-        </a>
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-5 py-3 transition duration-150 ease-linear hover:bg-gray-50 dark:hover:bg-gray-700">
+        <h3 className="min-w-[9rem] flex-1 text-sm text-gray-700 dark:text-gray-100">{date}</h3>
+        <div className="flex items-center gap-4 text-sm">
+          {meeting_recording?.embedUrl ? (
+            <a
+              onClick={() => {
+                toggleIsModalOpen(meeting_recording, date);
+              }}
+              className="cursor-pointer font-semibold text-purple-700 no-underline hover:text-purple-900 hover:underline dark:text-purple-500 dark:hover:text-purple-300">
+              {meeting_recording?.text}
+            </a>
+          ) : (
+            <a
+              className="font-semibold text-purple-700 no-underline hover:text-purple-900 hover:underline dark:text-purple-500 dark:hover:text-purple-300"
+              href={meeting_recording?.link}>
+              {meeting_recording?.text}
+            </a>
+          )}
+          <a
+            href={meeting_minutes?.path}
+            className="font-semibold text-blue-700 no-underline hover:text-blue-900 hover:underline dark:text-blue-500 dark:hover:text-blue-300">
+            {meeting_minutes?.text}
+          </a>
+        </div>
       </div>
     );
   }
 
   function getDropdownOption(options: DropdownOptionProps[]) {
-    return options.map(option => <DropDownOption {...option} />);
+    return options.map((option, index) => <DropDownOption key={index} {...option} />);
   }
 
-  populateMeetings();
-
-  let communityMeetingsData: SubcardGridProps[] = [];
-  let CabalMeetingsData: SubcardGridProps[] = [];
-
-  // get top 2 CommunityMeetings & CabalMeetings for subcards
-  for (let i = 0; i < 2; i++) {
-    let meeting = MeetingDropdownOptions.shift();
-    communityMeetingsData.push({
-      date: meeting?.date,
+  const buildSubcardData = (options: DropdownOptionProps[]): SubcardGridProps[] =>
+    options.slice(0, 2).map(meeting => ({
+      date: meeting.date,
       icon: 'film-icon',
+      embedUrl: meeting.meeting_recording?.embedUrl,
+      embedTitle: meeting.meeting_recording?.modalHeaderData,
       buttons: [
-        {
-          path: meeting?.meeting_recording?.link,
-          text: meeting?.meeting_recording?.text,
-        },
-        { ...meeting?.meeting_minutes },
+        // If we can embed the recording directly, skip the "Watch Recording"
+        // button entirely instead of making it open the same video in a modal.
+        ...(meeting.meeting_recording?.embedUrl
+          ? []
+          : [
+              {
+                path: meeting.meeting_recording?.link,
+                text: meeting.meeting_recording?.text,
+              },
+            ]),
+        { ...meeting.meeting_minutes },
       ],
-    });
-    meeting = cabalDropdownOptions.shift();
-    CabalMeetingsData.push({
-      date: meeting?.date,
-      icon: 'film-icon',
-      buttons: [
-        {
-          path: meeting?.meeting_recording?.link,
-          text: meeting?.meeting_recording?.text,
-        },
-        { ...meeting?.meeting_minutes },
-      ],
-    });
-  }
+    }));
+
+  const communityMeetingsData = buildSubcardData(communityOptions);
+  const cabalMeetingsData = buildSubcardData(cabalOptions);
 
   return (
-    <div className="justify-content-center align-items-center custom-card-grid-root flex">
-      {cards.map((card: CommunityMeetingsCardProps, index: number) => {
-        let meetingsData = index == 1 ? CabalMeetingsData : communityMeetingsData;
+    <div className="custom-card-grid-root flex flex-col items-center justify-center gap-x-8 lg:flex-row lg:items-stretch">
+      {cards.map((card, index) => {
+        const meetingsData = index == 1 ? cabalMeetingsData : communityMeetingsData;
+        const dropdownOptions = index == 1 ? cabalOptions : communityOptions;
         return (
           <div
             key={`card-container-${index}`}
-            className="align-items-center card-container mb-4 flex flex-1 flex-col flex-wrap justify-center transition duration-150 ease-linear lg:mb-6">
+            className="card-container mb-4 flex w-full flex-col flex-wrap items-center justify-start gap-4 transition duration-150 ease-linear lg:mb-6 lg:flex-1">
             <CustomCard
               key={`custom-card-${index}`}
               title={card?.title}
@@ -208,32 +214,30 @@ function CommunityMeetingsCardGrid({ cards }) {
               data={card?.buttons}
               primary={true}
             />
-            <SectionHeader
-              title=""
-              description="Most Recent meetings"
-              textGradientStops="from-purple-500 to-purple-700 dark:text-purple-500"
-              textGradient={false}
-            />
+            <div className="dark:text-purple-400 mb-2 mt-8 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-purple-700">
+              <Icon icon="mdi:history" className="text-base" />
+              Most Recent Meetings
+            </div>
             <SubcardGrid key={`subcard-grid-${index}`} cards={meetingsData} toggleIsModalOpen={toggleIsModalOpen} />
             <Dropdown
-              options={getDropdownOption(index == 1 ? [...cabalDropdownOptions] : [...MeetingDropdownOptions])}
+              options={getDropdownOption(dropdownOptions.slice(2))}
               dropdownRef={meetingMinutesRef[index]}
               text="Older meeting details"
             />
-            <dialog
-              className="bg-stone-200 w-90-screen h-80-screen fixed top-20 z-50 max-h-screen w-fit border-4 border-purple-100"
-              open={isModalOpen}
-              ref={modalRef}>
-              <div className="modal-content flex flex-col">
-                {modalHeader}
-                <div className="md-wrapper overflow-y-auto scrollbar-thin scrollbar-track-gray-100 scrollbar-thumb-gray-300 dark:bg-gray-700  dark:text-gray-50 dark:shadow-none">
-                  {meetinNotesMD}
-                </div>
-              </div>
-            </dialog>
           </div>
         );
       })}
+      <dialog
+        className="fixed top-1/2 z-50 w-[90vw] max-w-3xl -translate-y-1/2 overflow-hidden rounded-2xl border-0 bg-white p-0 shadow-2xl dark:bg-gray-700"
+        open={isModalOpen}
+        ref={modalRef}>
+        <div className="flex max-h-[80vh] flex-col">
+          {modalHeader}
+          <div className="modal-body overflow-y-auto p-6 scrollbar-thin scrollbar-track-gray-100 scrollbar-thumb-gray-300 dark:bg-gray-700 dark:text-gray-50">
+            {modalContent}
+          </div>
+        </div>
+      </dialog>
     </div>
   );
 }

--- a/src/components/layout/CommunityMeetingsCardGrid/styles.css
+++ b/src/components/layout/CommunityMeetingsCardGrid/styles.css
@@ -1,40 +1,14 @@
-/* colors (current tailwind standard colors but not included with currently using tailwind installation) */
-.bg-stone-200 {
-  background-color: rgb(231 229 228);
-}
-
-/* width custom classes */
-.w-90-screen {
-  width: 90vw;
-}
-
-/* height custom classes */
-.h-80-screen {
-  height: 85vh;
-}
-
 .close-icon {
   cursor: pointer;
 }
 
-.md-wrapper {
-  padding: 2rem;
-  height: 75vh;
+.modal-body h1,
+.modal-body h2,
+.modal-body h3 {
+  padding: 0.5rem 0;
 }
 
-.md-wrapper h1,
-h2,
-h3 {
-  padding: 0.5rem;
-}
-
-dialog {
-  padding: 0;
-}
-
-.modal-header {
-  background-color: white;
-  padding: 1rem;
-  display: inline-flex;
-  justify-content: space-between;
+dialog::backdrop {
+  background-color: rgb(0 0 0 / 0.5);
+  backdrop-filter: blur(4px);
 }

--- a/src/components/layout/HeroHeader/index.tsx
+++ b/src/components/layout/HeroHeader/index.tsx
@@ -3,9 +3,9 @@ import BrowserOnly from '@docusaurus/BrowserOnly';
 import { Icon } from '@iconify/react';
 import Button from '@site/src/components/utilities/Button';
 import DropdownButton from '@site/src/components/utilities/DropdownButton';
-import Link from '@site/src/components/utilities/Link';
 import WaveBorder from '@site/src/components/shapes/WaveBorder';
 import operatingSystemData from './installOptions';
+import { detectOperatingSystem } from '@site/src/lib/detectOperatingSystem';
 type InstallOptionProps = Card & {
   icon: string;
   option?: React.ReactNode;
@@ -14,123 +14,108 @@ type InstallOptionProps = Card & {
   other?: { path: string; text: string; subtext: string };
 };
 
-const detectOperatingSystem = () => {
-  const userAgent = window.navigator.userAgent.toLowerCase().split(' ');
-  if (userAgent.find(item => item.includes('windows'))) {
-    return 'windows';
-  } else if (userAgent.find(item => item.includes('macintosh'))) {
-    return 'mac';
-  }
-  return 'linux';
-};
-
 function returnOperatingSystemData() {
-  const os = operatingSystemData.find(os => os.id === detectOperatingSystem() && os);
-  return os;
+  const os = operatingSystemData.find(os => os.id === detectOperatingSystem());
+  return { os };
 }
+
+const InstallOptionRow = ({
+  title,
+  subtitle,
+  icon,
+  path,
+}: {
+  title: string;
+  subtitle: string;
+  icon: string;
+  path: string;
+}): JSX.Element => (
+  <a
+    href={path}
+    className="group flex items-center gap-4 px-4 py-3.5 no-underline transition duration-150 ease-linear hover:bg-purple-50 hover:no-underline dark:hover:bg-purple-500/10">
+    <span className="dark:text-purple-400 flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-purple-50 text-xl text-purple-700 transition duration-150 ease-linear group-hover:bg-purple-700 group-hover:text-white dark:bg-purple-500/10 dark:group-hover:bg-purple-500 dark:group-hover:text-white">
+      <Icon icon={icon} />
+    </span>
+    <div className="min-w-0">
+      <h4 className="truncate text-sm font-semibold text-gray-900 dark:text-gray-50">{title}</h4>
+      <p className="truncate text-xs text-gray-500 dark:text-gray-300">{subtitle}</p>
+    </div>
+  </a>
+);
 
 const InstallOption = (props): JSX.Element => {
   if (!props) {
     props = operatingSystemData[0];
   }
   return (
-    <section>
-      <div>
-        <a
-          href={props.preferred.path}
-          className="block rounded-t-md text-purple-900 no-underline transition duration-150 ease-linear hover:bg-purple-700 hover:text-white hover:no-underline dark:text-white dark:hover:bg-purple-900 dark:hover:text-gray-300">
-          <div className="flex items-center gap-4 px-4 pb-6 pt-4">
-            <div>
-              <h3>{props.preferred.title}</h3>
-              <p>{props.preferred.subtitle}</p>
-            </div>
-            <Icon icon={props.preferred.icon} className="order-first text-4xl" />
-          </div>
-        </a>
+    <section className="w-80">
+      <div className="divide-y divide-gray-100 py-1 dark:divide-gray-700">
+        <InstallOptionRow {...props.preferred} />
+        <InstallOptionRow {...props.alt} />
+        {props.third && <InstallOptionRow {...props.third} />}
       </div>
-      <div>
-        <a
-          href={props.alt.path}
-          className="block text-purple-900 no-underline transition duration-150 ease-linear hover:bg-purple-700 hover:text-white hover:no-underline dark:text-white dark:hover:bg-purple-900 dark:hover:text-gray-300">
-          <div className="flex items-center gap-4 px-4 pb-6 pt-4">
-            <div>
-              <h4>{props.alt.title}</h4>
-              <p>{props.alt.subtitle}</p>
-            </div>
-            <Icon icon={props.alt.icon} className="order-first text-4xl" />
-          </div>
-        </a>
-      </div>
-      {props.third && (
-        <div>
-          <a
-            href={props.third.path}
-            className="block text-purple-900 no-underline transition duration-150 ease-linear hover:bg-purple-700 hover:text-white hover:no-underline dark:text-white dark:hover:bg-purple-900 dark:hover:text-gray-300">
-            <div className="flex items-center gap-4 px-4 pb-6 pt-4">
-              <div>
-                <h4>{props.third.title}</h4>
-                <p>{props.third.subtitle}</p>
-              </div>
-              <Icon icon={props.third.icon} className="order-first text-4xl" />
-            </div>
-          </a>
+      <a
+        href={props.other.path}
+        className="flex items-center justify-between gap-2 border-t border-gray-100 bg-gray-50 px-4 py-3 no-underline transition duration-150 ease-linear hover:bg-purple-50 hover:no-underline dark:border-gray-700 dark:bg-gray-900 dark:hover:bg-purple-500/10">
+        <div className="min-w-0">
+          <h5 className="dark:text-purple-400 truncate text-sm font-semibold text-purple-700">{props.other.text}</h5>
+          {props.other.subtext && (
+            <p className="truncate text-xs text-gray-500 dark:text-gray-300">{props.other.subtext}</p>
+          )}
         </div>
-      )}
-      <div>
-        <a
-          href={props.other.path}
-          className="block rounded-b-md bg-gray-50 py-2 text-purple-900 no-underline transition duration-150 ease-linear hover:bg-purple-700 hover:text-white hover:no-underline dark:bg-gray-700 dark:text-white dark:hover:bg-purple-900 dark:hover:text-gray-300">
-          <div className="px-4 py-2">
-            <div className="flex items-center gap-2">
-              <h5 className="row-start-1">{props.other.text}</h5>
-              <Icon icon="material-symbols:arrow-circle-right-rounded" className="row-start-1 text-xl" />
-            </div>
-            <p>{props.other.subtext}</p>
-          </div>
-        </a>
-      </div>
+        <Icon icon="mdi:arrow-right" className="dark:text-purple-400 shrink-0 text-lg text-purple-700" />
+      </a>
     </section>
   );
 };
 
-function HeroHeader({ title, subtitle, podmanrelease, desktoprelease, image, platforms }) {
+const VersionBadge = ({ icon, text, path }: { icon: string; text: string; path: string }): JSX.Element => (
+  <a
+    href={path}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border border-white/25 bg-white/10 px-3 py-1.5 text-sm font-medium text-white no-underline transition duration-150 ease-linear hover:border-white/40 hover:bg-white/20 hover:text-white hover:no-underline">
+    <Icon icon={icon} className="text-sm" />
+    {text}
+  </a>
+);
+
+function HeroHeader({ title, subtitle, podmanrelease, desktoprelease, image, platforms, platformsLabel }) {
   return (
     <header className="bg-gradient-to-r from-blue-500 to-purple-700 dark:from-blue-700 dark:to-purple-900">
-      <div className="mx-auto grid md:grid-cols-2 md:gap-12 xl:mx-20">
+      <div className="mx-auto grid px-4 sm:px-6 md:grid-cols-2 md:gap-12 xl:mx-20">
         <div className="container row-span-2 mb-4 mt-12 place-self-end md:mb-0 md:ml-10 xl:ml-24">
           <h1 className="mb-4 text-white dark:text-gray-50 lg:mb-8">{title}</h1>
           <p className="max-w-sm text-white dark:text-gray-50 lg:max-w-prose">{subtitle}</p>
           <div className="my-3 flex max-w-sm gap-8 text-lg">
             <Button as="link" text="Get Started" path="/get-started" />
             <BrowserOnly>
-              {() => <DropdownButton text="Download" option={InstallOption(returnOperatingSystemData())} />}
+              {() => {
+                const { os } = returnOperatingSystemData();
+                return <DropdownButton text="Download" option={InstallOption(os)} />;
+              }}
             </BrowserOnly>
           </div>
-          <p className="flex gap-4 text-white dark:text-gray-100">
-            <span>
-              Latest stable Podman <Link {...podmanrelease} textColor="text-white dark:text-gray-100" />
-            </span>
-            <span>-</span>
-            <span>
-              Latest stable Podman Desktop <Link {...desktoprelease} textColor="text-white dark:text-gray-100" />
-            </span>
-            <span>-</span>
-            <Link
-              text="Apache License 2.0"
-              path="https://www.apache.org/licenses/LICENSE-2.0"
-              textColor="text-white dark:text-gray-100"
-            />
-          </p>
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <VersionBadge icon="simple-icons:podman" text={`Podman ${podmanrelease.text}`} path={podmanrelease.path} />
+            <VersionBadge icon="ph:desktop-fill" text={`Desktop ${desktoprelease.text}`} path={desktoprelease.path} />
+            <VersionBadge icon="ph:scales-fill" text="Apache 2.0" path="https://www.apache.org/licenses/LICENSE-2.0" />
+          </div>
         </div>
 
         <div className="container mx-auto flex flex-col justify-end self-end md:col-start-2 md:row-span-3 lg:row-span-2 lg:row-start-2">
           <div className="container mb-12 flex flex-col items-start md:mb-0 md:max-w-lg lg:max-w-full lg:items-end 2xl:pr-8">
-            <h3 className="text-base font-medium text-white dark:text-gray-100">{platforms[0]}</h3>
+            <h3 className="text-base font-medium text-white dark:text-gray-100">{platformsLabel}</h3>
             <ul className="flex gap-4">
-              {platforms.slice(1).map((icon, index) => {
+              {platforms.map(platform => {
                 return (
-                  <li key={index}>
-                    <Icon icon={icon} className="text-3xl text-white dark:text-gray-100" />
+                  <li key={platform.label}>
+                    <a
+                      href={platform.path}
+                      aria-label={platform.label}
+                      className="block rounded-full p-1 text-white no-underline transition duration-150 ease-linear hover:-translate-y-0.5 hover:text-purple-300 hover:no-underline dark:text-gray-100">
+                      <Icon icon={platform.icon} className="text-3xl" />
+                    </a>
                   </li>
                 );
               })}

--- a/src/components/layout/HeroHeader/installOptions.ts
+++ b/src/components/layout/HeroHeader/installOptions.ts
@@ -2,7 +2,7 @@ import { LATEST_VERSION, LATEST_DESKTOP_VERSION } from '@site/static/data/global
 const operatingSystemData = [
   {
     id: 'windows',
-    preferred:{
+    preferred: {
       title: 'Podman Desktop for Windows',
       subtitle: `Windows Installer v-${LATEST_DESKTOP_VERSION}`,
       icon: 'fa-brands:windows',
@@ -24,7 +24,7 @@ const operatingSystemData = [
       path: `https://github.com/podman-container-tools/podman/releases/download/v${LATEST_VERSION}/podman-installer-windows-arm64.msi`,
     },
     other: {
-      path: 'docs/installation',
+      path: '/downloads',
       text: 'Other Install Options',
     },
   },
@@ -44,7 +44,7 @@ const operatingSystemData = [
       path: `https://github.com/podman-container-tools/podman/releases/download/v${LATEST_VERSION}/podman-installer-macos-arm64.pkg`,
     },
     other: {
-      path: 'docs/installation',
+      path: '/downloads',
       text: 'Other Install Options',
     },
   },
@@ -54,7 +54,7 @@ const operatingSystemData = [
       title: 'Podman CLI for Linux',
       subtitle: `Podman Engine v${LATEST_VERSION}`,
       icon: 'material-symbols:terminal-rounded',
-      path: `docs/installation#installing-on-linux`,
+      path: `/docs/installation#installing-on-linux`,
     },
     alt: {
       title: 'Podman Desktop for Linux',
@@ -63,7 +63,7 @@ const operatingSystemData = [
       path: `https://github.com/podman-desktop/podman-desktop/releases/download/v${LATEST_DESKTOP_VERSION}/podman-desktop-${LATEST_DESKTOP_VERSION}.flatpak`,
     },
     other: {
-      path: 'docs/installation',
+      path: '/downloads',
       text: 'Other Install Options',
     },
   },

--- a/src/components/layout/PageHeader/index.tsx
+++ b/src/components/layout/PageHeader/index.tsx
@@ -1,6 +1,5 @@
 import React, { PropsWithChildren } from 'react';
 import { Icon } from '@iconify/react';
-import WaveBorder from '@site/src/components/shapes/WaveBorder';
 import Markdown from '@site/src/components/utilities/Markdown';
 import BasicResourcesBox from '@site/src/components/content/BasicResourcesBox';
 type ImageSectionProps = LayoutProps & {
@@ -14,36 +13,51 @@ type PageHeaderProps = LayoutProps &
     darkColor?: string;
     lightColor?: string;
     basicResources?: boolean;
-    instructions?: { [key:string]: any };
+    instructions?: { [key: string]: any };
   };
 
 type PageHeaderSupplementalInfoProps = PageHeaderProps & {
   image?: Image;
   basicResources?: boolean;
-}
+};
 
 type InstructionsProps = PageHeaderProps & {
-  instructions?: { [key:string]: any };
-}
+  instructions?: { [key: string]: any };
+};
 
 const TextBox = ({ grid, display, layout, title, description }: PageHeaderProps): JSX.Element => {
   return (
     <div className={`${grid} ${display} ${layout}`}>
-      <h1 className="mb-6 max-w-sm text-purple-700 dark:text-purple-500 lg:max-w-lg ">{title}</h1>
+      <h1 className="mb-6 max-w-sm text-purple-700 dark:text-purple-500 lg:max-w-lg">{title}</h1>
       <Markdown text={description} styles="leading-relaxed" />
     </div>
   );
 };
 
+const DecorativeBlob = () => (
+  <div className="pointer-events-none absolute -inset-8 z-0 flex items-center justify-center">
+    <svg viewBox="0 0 200 200" className="h-full w-full text-purple-100 dark:text-purple-500/10">
+      <path
+        fill="currentColor"
+        d="M52.4,-58.5C66.4,-49.6,75.6,-32.1,78.4,-13.7C81.2,4.7,77.6,24,67.4,39.4C57.2,54.8,40.4,66.3,21.6,71.6C2.8,76.9,-18,75.9,-35.9,67.6C-53.8,59.3,-68.8,43.6,-74.9,25.2C-81,6.8,-78.2,-14.3,-68.5,-31.2C-58.8,-48.1,-42.2,-60.8,-24.9,-68.5C-7.6,-76.2,10.4,-78.9,26.7,-74.6C43,-70.3,52.4,-58.5,52.4,-58.5Z"
+        transform="translate(100 100)"
+      />
+    </svg>
+    <Icon icon="mdi:sparkles" className="absolute left-0 top-0 text-lg text-purple-300 dark:text-purple-300/40" />
+    <Icon icon="mdi:sparkles" className="absolute bottom-2 right-0 text-base text-purple-300 dark:text-purple-300/40" />
+    <span className="absolute right-4 top-6 h-2 w-2 rounded-full bg-purple-300 dark:bg-purple-300/30" />
+    <span className="absolute bottom-6 left-2 h-1.5 w-1.5 rounded-full bg-purple-300 dark:bg-purple-300/30" />
+  </div>
+);
+
 const Image = ({
-  grid,
-  display,
-  layout,// if array then {[key:string]: any}[];
-  image = { path: 'images/optimized/podman-2-196w-172h.webp', alt: 'Podman Logo' },
+  layout, // if array then {[key:string]: any}[];
+  image = { path: '/images/optimized/podman-2-196w-172h.webp', alt: 'Podman Logo' },
 }: ImageSectionProps) => {
   return (
-    <div>
-      <img src={image.path} alt={image.alt} className={`${grid} ${display} ${layout}`} />
+    <div className={`relative mx-auto w-full max-w-[220px] md:max-w-[260px] ${layout ?? ''}`}>
+      <DecorativeBlob />
+      <img src={image.path} alt={image.alt} className="relative z-10 h-auto w-full object-contain" />
     </div>
   );
 };
@@ -51,51 +65,56 @@ const Image = ({
 function PageHeaderSupplementalInfo({ image, basicResources }: PageHeaderSupplementalInfoProps) {
   if (basicResources) {
     return (
-      <BasicResourcesBox />
+      <div className="mx-auto w-full max-w-sm">
+        <BasicResourcesBox />
+      </div>
     );
-  } 
-  return (
-    <Image image={image} layout="mb-8 lg:mb-0" />
-  );
+  }
+  return <Image image={image} layout="mb-8 lg:mb-0" />;
 }
 
 function Instructions({ instructions }: InstructionsProps) {
   if (instructions) {
     return (
       <div>
-        <h3 className="text-gray-700 mb-4">{instructions.title}</h3>
+        <h3 className="mb-4 text-gray-700 dark:text-gray-100">{instructions.title}</h3>
         <p>{instructions.subtitle}</p>
-         <ul className="mb-10 mt-4 flex flex-col gap-6 sm:flex-row lg:mb-16 lg:gap-4 xl:flex-col">
-              <li>
-                <a
-                  href={instructions.button.path}
-                  className="no-underline hover:no-underline flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center text-purple-700 underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:shadow-md dark:bg-gray-700 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
-                  <span>{instructions.button.text}</span>
-                  <Icon icon={instructions.button.icon} className="order-first hidden lg:block" />
-                </a>
-              </li>
+        <ul className="mb-10 mt-4 flex flex-col gap-6 sm:flex-row lg:mb-16 lg:gap-4 xl:flex-col">
+          <li>
+            <a
+              href={instructions.button.path}
+              className="flex h-32 max-w-lg flex-col items-center justify-center gap-4 rounded-md bg-gray-100 p-4 text-center text-purple-700 no-underline underline-offset-4 transition duration-150 ease-linear hover:bg-purple-700 hover:text-purple-50 hover:no-underline hover:shadow-md dark:bg-gray-700 dark:text-purple-300 dark:hover:bg-purple-900 dark:hover:text-white lg:h-auto lg:flex-row xl:justify-start">
+              <span>{instructions.button.text}</span>
+              <Icon icon={instructions.button.icon} className="order-first hidden lg:block" />
+            </a>
+          </li>
         </ul>
       </div>
-    )
+    );
   }
   return null;
 }
 
-function PageHeader({ title, description, image, lightColor = 'white', darkColor = 'gray-900', basicResources, instructions }: PageHeaderProps) {
+function PageHeader({
+  title,
+  description,
+  image,
+  lightColor = 'white',
+  darkColor = 'gray-900',
+  basicResources,
+  instructions,
+}: PageHeaderProps) {
   return (
     <header className={`bg-${lightColor} dark:bg-${darkColor}`}>
-      <div className="bg-gradient-to-r  from-blue-500 to-purple-700 dark:from-blue-700 dark:to-purple-900 lg:pt-8">
-        <WaveBorder />
-      </div>
-      <div className="container flex flex-col md:flex-row justify-around">
-        <div>
+      <div className="h-24 lg:h-32" />
+      <div className="container flex flex-col md:flex-row md:items-center md:gap-12 lg:gap-20">
+        <div className="md:flex-1">
           <TextBox title={title} description={description} layout="mt-12 lg:mt-0 mb-8" />
           <Instructions instructions={instructions} />
         </div>
-        <div className="w-[50%] ml-24">
+        <div className="mt-8 w-full shrink-0 md:mt-0 md:w-auto">
           <PageHeaderSupplementalInfo basicResources={basicResources} />
         </div>
-
       </div>
     </header>
   );

--- a/src/components/layout/SectionHeader/index.tsx
+++ b/src/components/layout/SectionHeader/index.tsx
@@ -22,11 +22,11 @@ function SectionHeader({
   bgColor,
 }: SectionHeaderProps): JSX.Element {
   const applyTextColor = textGradient
-    ? `bg-gradient-radial bg-clip-text text-transparent dark:bg-gradient-radial dark:text-transparent ${textGradientStops}`
+    ? `bg-gradient-to-r bg-clip-text text-transparent dark:bg-gradient-to-r dark:text-transparent ${textGradientStops}`
     : `${textColor}`;
   return (
-    <header className={`${bgColor}  ${layout}`}>
-      <div className="container mx-auto mb-4 mt-12 text-center  lg:mt-16">
+    <header className={`${bgColor} ${layout}`}>
+      <div className="container mx-auto mb-4 mt-12 text-center lg:mt-16">
         <h2 className={`${applyTextColor} ${fontWeight}`}>{title}</h2>
         <Markdown text={description} styles="mx-auto my-4 max-w-4xl leading-relaxed text-gray-700 dark:text-gray-100" />
       </div>

--- a/src/components/layout/SubcardGrid/index.tsx
+++ b/src/components/layout/SubcardGrid/index.tsx
@@ -4,7 +4,7 @@ import { DayOfTheWeek } from '@site/src/components/utilities/DateUtils';
 
 function SubcardGrid({ cards, toggleIsModalOpen }) {
   return (
-    <div className="mb-4 flex lg:mb-6">
+    <div className="mb-4 flex w-full flex-col items-center gap-4 sm:flex-row sm:items-stretch lg:mb-6">
       {cards?.map((card, index) => {
         let date = new Date(card.date).getDay();
         return (
@@ -16,6 +16,8 @@ function SubcardGrid({ cards, toggleIsModalOpen }) {
             text={card.subtitle}
             data={card.buttons}
             icon={card.icon}
+            embedUrl={card.embedUrl}
+            embedTitle={card.embedTitle}
             method={meeting_minutes => {
               toggleIsModalOpen(meeting_minutes, card.date);
             }}

--- a/src/components/pages/MeetingNotePage/index.tsx
+++ b/src/components/pages/MeetingNotePage/index.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import Markdown from '@site/src/components/utilities/Markdown';
+import VideoEmbed from '@site/src/components/ui/VideoEmbed';
+
+type MeetingNote = {
+  slug: string;
+  displayDate: string;
+  title: string;
+  recordingLink?: string;
+  recordingEmbedUrl?: string;
+  content: string;
+};
+
+// The page already renders the title in its own header, so drop the matching
+// leading `# Title` line from the markdown to avoid showing it twice.
+function stripLeadingTitle(content: string, title: string): string {
+  return content.replace(new RegExp(`^#\\s+${title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\n`), '');
+}
+
+function MeetingNotePage({ note }: { note: MeetingNote }): JSX.Element {
+  return (
+    <Layout title={`${note.title} - ${note.displayDate}`} description="Podman Community meeting notes">
+      <article className="container mx-auto max-w-3xl py-12">
+        <a
+          href="/community"
+          className="mb-6 inline-block text-sm font-semibold text-purple-700 no-underline hover:text-purple-900 hover:underline dark:text-purple-500 dark:hover:text-purple-300">
+          ← Back to Community
+        </a>
+        <header className="mb-8 text-center">
+          <h1 className="mb-2 text-purple-700 dark:text-purple-500">{note.title}</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-300">{note.displayDate}</p>
+        </header>
+        {note.recordingEmbedUrl ? (
+          <div className="mb-8">
+            <VideoEmbed url={note.recordingEmbedUrl} title={note.title} />
+          </div>
+        ) : note.recordingLink ? (
+          <p className="mb-8 text-center">
+            <a
+              href={note.recordingLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-purple-700 no-underline hover:text-purple-900 hover:underline dark:text-purple-500 dark:hover:text-purple-300">
+              Watch Recording
+            </a>
+          </p>
+        ) : null}
+        <Markdown text={stripLeadingTitle(note.content, note.title)} styles="max-w-none" />
+      </article>
+    </Layout>
+  );
+}
+
+export default MeetingNotePage;

--- a/src/components/ui/ArticleCard/index.tsx
+++ b/src/components/ui/ArticleCard/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Icon } from '@iconify/react';
 import parse from 'html-react-parser';
 type ArticleCardProps = {
   title: string;
@@ -13,89 +14,103 @@ type ArticleCardProps = {
 };
 
 const FALLBACK_IMAGES = [
-  'images/raw/characters/seal-diving.png',
-  'images/raw/characters/seals-swimming.png',
-  'images/raw/characters/confused-seal.png',
-  'images/raw/podman-selkie-385w-358h.png',
+  '/images/raw/characters/seal-diving.png',
+  '/images/raw/characters/seals-swimming.png',
+  '/images/raw/characters/confused-seal.png',
+  '/images/raw/podman-selkie-385w-358h.png',
 ];
 
 const PublishDate = ({ date, styles }: { date: string; styles?: string }) => {
   return (
     <div
-      className={`${styles} h-fit max-w-fit rounded-sm bg-gradient-radial from-blue-500 to-blue-700 px-2 text-white shadow-md dark:from-blue-900 dark:to-blue-900`}>
-      <p className="font-semibold shadow-sm">{date}</p>
+      className={`${styles} flex h-fit max-w-fit items-center gap-1 rounded-full border border-white/60 bg-white/80 px-2.5 py-1 text-gray-700 shadow-sm backdrop-blur dark:border-white/10 dark:bg-gray-900/80 dark:text-gray-300`}>
+      <Icon icon="mdi:calendar-blank-outline" className="text-xs text-purple-700 dark:text-purple-300" />
+      <p className="text-xs font-semibold">{date}</p>
     </div>
   );
-};
-const Title = (title: string) => {
-  return <h3 className="text-purple-700">{title}</h3>;
 };
 
 function ArticleCard(props: ArticleCardProps) {
   // Select fallback image based on index, cycling through available images
   const fallbackImage = FALLBACK_IMAGES[(props.index || 0) % FALLBACK_IMAGES.length];
-  
+
   // Sanitizes HTML and converts it to plain text
   const sanitizeHtml = (html: string) => {
     if (!html) return html;
-    const div = document.createElement("div");
+    const div = document.createElement('div');
     div.innerHTML = html;
-    return div.textContent || div.innerText || "";
+    return div.textContent || div.innerText || '';
   };
   const abbrSubtitle = sanitizeHtml(props.subtitle).trim().split(' ').slice(0, 32).join(' ').concat('...');
+
+  const TitleLink = ({ className }: { className?: string }) => (
+    <h3 className={`text-lg font-bold leading-snug text-gray-900 dark:text-white ${className ?? ''}`}>
+      <a
+        href={props.path}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-gray-900 no-underline transition duration-150 ease-linear hover:text-purple-700 hover:no-underline dark:text-white dark:hover:text-purple-300">
+        {sanitizeHtml(props.title)}
+      </a>
+    </h3>
+  );
+
+  const Byline = () => (
+    <div className="flex items-center gap-2">
+      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-purple-100 text-purple-700 dark:bg-purple-500/10 dark:text-purple-300">
+        <Icon icon="mdi:account" className="text-sm" />
+      </span>
+      <a
+        href={props.author_link}
+        className="text-sm text-gray-500 no-underline transition duration-150 ease-linear hover:text-purple-700 hover:no-underline dark:text-gray-300 dark:hover:text-purple-300">
+        {props.display_name}
+      </a>
+    </div>
+  );
+
   if (props.altLayout) {
     return (
-      <article className="my-4 max-w-2xl shadow-lg">
-        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-          <div className="grid items-end xl:basis-5/12">
-            <div className="z-10 col-start-1 row-start-1">
-              <h3 className="w-9/12 bg-gradient-radial from-purple-700 to-purple-900 p-2 text-white shadow-sm">
-                <a
-                  href={props.path}
-                  target="_blank"
-                  className="text-white no-underline hover:text-blue-100 hover:no-underline dark:text-white dark:hover:text-blue-50">
-                  {sanitizeHtml(props.title)}
-                </a>
-              </h3>
-              <PublishDate date={props.date} styles="col-start-1 order-1 row-start-1 z-10" />
-            </div>
-            <img
-              src={props.imgSrc || fallbackImage}
-              className=" col-start-1 row-start-1 h-full w-full rounded-sm object-cover lg:w-80"
-            />
-          </div>
-          <div className="max-w-sm items-center gap-2 self-center p-2 pr-4">
+      <article className="group my-4 flex max-w-2xl flex-col overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm transition-all duration-300 ease-out hover:-translate-y-1 hover:border-purple-300 hover:shadow-xl hover:shadow-purple-500/10 dark:border-white/10 dark:bg-gray-900 dark:hover:border-purple-500/30 dark:hover:shadow-purple-900/20 sm:grid sm:grid-cols-2">
+        <div className="relative aspect-[16/10] w-full self-center overflow-hidden sm:aspect-square">
+          <img
+            src={props.imgSrc || fallbackImage}
+            alt=""
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+          <PublishDate date={props.date} styles="absolute left-3 top-3 z-10" />
+        </div>
+        <div className="flex flex-col justify-center gap-3 p-6">
+          <TitleLink />
+          <div className="line-clamp-3 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
             {parse(abbrSubtitle)}
-            <p className="mt-2 text-purple-700">
-              By: <a href={props.author_link}>{props.display_name}</a>
-            </p>
           </div>
+          <Byline />
         </div>
       </article>
     );
   }
   // Normal Layout
-  else
-    return (
-      <article className="my-4 max-w-sm p-4">
-        <div className="grid">
-          <h3 className="w-10/12 rounded-sm bg-gradient-radial from-purple-700 to-purple-900 px-2 py-1 text-white shadow-sm">
-            <a
-              href={props.path}
-              target="_blank"
-              className="text-white no-underline hover:text-blue-100 hover:no-underline dark:text-white dark:hover:text-blue-50">
-              {sanitizeHtml(props.title)}
-            </a>
-          </h3>
+  return (
+    <article className="group mx-auto flex w-full max-w-sm flex-col overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm transition-all duration-300 ease-out hover:-translate-y-1 hover:border-purple-300 hover:shadow-xl hover:shadow-purple-500/10 dark:border-white/10 dark:bg-gray-900 dark:hover:border-purple-500/30 dark:hover:shadow-purple-900/20">
+      <div className="relative aspect-[16/10] w-full overflow-hidden">
+        <img
+          src={props.imgSrc || fallbackImage}
+          alt=""
+          className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+        />
+        <PublishDate date={props.date} styles="absolute left-3 top-3 z-10" />
+      </div>
+      <div className="flex flex-1 flex-col gap-2 p-5">
+        <TitleLink className="line-clamp-2" />
+        <div className="line-clamp-3 flex-1 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
           {parse(abbrSubtitle)}
-          <PublishDate date={props.date} styles="row-start-1 col-start-1 z-10 my-2" />
-          <img src={props.imgSrc || fallbackImage} className="object-fit col-start-1 row-start-1 rounded-sm" />
-          <p className="text-purple-700">
-            By: <a href={props.author_link}>{props.display_name}</a>
-          </p>
         </div>
-      </article>
-    );
+        <div className="mt-1 border-t border-gray-100 pt-3 dark:border-white/10">
+          <Byline />
+        </div>
+      </div>
+    </article>
+  );
 }
 
 export default ArticleCard;

--- a/src/components/ui/Card/index.tsx
+++ b/src/components/ui/Card/index.tsx
@@ -21,7 +21,7 @@ function CardBody(props) {
 }
 function CardButtons({ data = [{ text: 'button text' }] }) {
   return (
-    <div className=" mx-2 mb-4 flex justify-center gap-2 lg:mb-8">
+    <div className="mx-2 mb-4 flex justify-center gap-2 lg:mb-8">
       {data.map((button, index) => (
         <div key={index}>
           {index == 0 ? <Button as="link" {...button} /> : <Button as="link" outline={true} {...button} />}
@@ -33,7 +33,7 @@ function CardButtons({ data = [{ text: 'button text' }] }) {
 
 function Card(props) {
   return (
-    <article className="m-4 flex flex-col justify-between rounded-lg bg-gray-50 p-4 shadow-xl dark:bg-gray-700 dark:shadow-none lg:m-2">
+    <article className="m-4 flex flex-col justify-between rounded-xl border border-gray-100 bg-gray-50 p-4 shadow-xl transition duration-200 hover:-translate-y-1 hover:shadow-2xl dark:border-gray-500 dark:bg-gray-700 dark:shadow-none lg:m-2">
       <CardHeader {...props} />
       <CardBody {...props} />
       <CardButtons {...props} />

--- a/src/components/ui/CustomCard/index.tsx
+++ b/src/components/ui/CustomCard/index.tsx
@@ -1,12 +1,16 @@
 import React, { ReactNode } from 'react';
+import { Icon } from '@iconify/react';
 import Button from '@site/src/components/utilities/Button/';
 import Markdown from '@site/src/components/utilities/Markdown';
+import VideoEmbed from '@site/src/components/ui/VideoEmbed';
 import FilmIcon from '../../shapes/FilmIcon';
 
 type SubcardButtonProps = {
   text: string;
   path?: string;
   markDown?: ReactNode;
+  embedUrl?: string;
+  modalHeaderData?: string;
 };
 
 type CardInfoButtonProps = {
@@ -15,24 +19,10 @@ type CardInfoButtonProps = {
   method: Function;
 };
 
-function CardHeader(props) {
-  const { title, subtitle, details } = props;
+function CardBody({ text, className = '' }: { text: string; className?: string }) {
   return (
-    <div className="mx-2 mb-10 mt-4 text-center">
-      <h3 className="mb-3 whitespace-nowrap font-bold text-gray-700 dark:text-gray-50">{title}</h3>
-      <Markdown text={subtitle} styles="text-gray-700" />
-      <Markdown text={details} styles="text-gray-700" />
-    </div>
-  );
-}
-
-function CardBody(props) {
-  const { text } = props;
-  return (
-    <div className="mx-2 my-6 overflow-y-auto lg:my-8">
-      <p id="cardBody-parsed" className="text-gray-700 dark:text-gray-100">
-        <Markdown text={text} />
-      </p>
+    <div className={`overflow-y-auto text-gray-700 dark:text-gray-100 ${className}`}>
+      <Markdown text={text} />
     </div>
   );
 }
@@ -48,7 +38,7 @@ function CardInfoButtons(cardInfoButtonProps: CardInfoButtonProps) {
     },
   } = cardInfoButtonProps;
   return (
-    <div className="align-center mb-4 mt-8 flex flex-row flex-wrap justify-center gap-4 lg:mb-8 2xl:px-10">
+    <div className={`flex flex-row flex-wrap gap-3 ${primary ? 'mt-4 justify-start' : 'mt-3 justify-center'}`}>
       {primary
         ? data.map((button, index) => (
             <div key={index}>
@@ -57,7 +47,7 @@ function CardInfoButtons(cardInfoButtonProps: CardInfoButtonProps) {
           ))
         : data.map((button, index) => (
             <div key={index}>
-              {index == 0 ? (
+              {button.path ? (
                 <Button as="link" outline={true} {...button} />
               ) : (
                 <Button
@@ -75,16 +65,55 @@ function CardInfoButtons(cardInfoButtonProps: CardInfoButtonProps) {
   );
 }
 
-function CustomCard(props) {
+// Primary cards (the two meeting-type cards) get a colored schedule rail down the side.
+function PrimaryCard(props) {
+  const { title, subtitle, details, text } = props;
   return (
-    <article
-      style={props.primary ? { maxHeight: '550px', flex: 1 } : {}}
-      className="flex w-11/12 flex-col rounded-lg bg-gray-50 p-4 shadow-xl dark:bg-gray-700 dark:shadow-none lg:mx-8 lg:my-4">
-      <CardHeader {...props} />
-      {props?.icon ? <FilmIcon /> : <CardBody {...props} />}
-      <CardInfoButtons {...props} />
+    <article className="grid w-full grid-cols-1 overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-md transition duration-200 hover:-translate-y-1 hover:shadow-xl dark:border-gray-700 dark:bg-gray-900 sm:grid-cols-[12rem_1fr]">
+      <div className="flex flex-row items-center gap-4 bg-gradient-to-br from-purple-700 to-purple-900 p-5 text-white dark:from-purple-900 dark:to-black sm:flex-col sm:justify-center sm:gap-3 sm:p-6 sm:text-center">
+        <Icon icon="mdi:calendar-month-outline" className="shrink-0 text-3xl text-purple-100" />
+        <div>
+          {subtitle && <Markdown text={subtitle} styles="text-sm font-semibold leading-snug [&>p]:m-0" />}
+          {details && <Markdown text={details} styles="mt-1.5 text-xs text-purple-100 [&>p]:m-0" />}
+        </div>
+      </div>
+      <div className="flex flex-col p-6">
+        <h3 className="mb-3 text-blue-700 dark:text-blue-500">{title}</h3>
+        <CardBody text={text} className="text-sm leading-relaxed" />
+        <CardInfoButtons {...props} />
+      </div>
     </article>
   );
+}
+
+// Subcards (recent meeting recordings) get the date/day stamped directly on the video thumbnail.
+function SubCard(props) {
+  const { title, subtitle, embedUrl, embedTitle, icon } = props;
+  return (
+    <article className="flex w-full flex-col overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-md transition duration-200 hover:-translate-y-1 hover:shadow-xl dark:border-gray-700 dark:bg-gray-900">
+      <div className="relative">
+        {embedUrl ? (
+          <VideoEmbed url={embedUrl} title={embedTitle || title} />
+        ) : icon ? (
+          <div className="flex aspect-video w-full items-center justify-center bg-gray-100 dark:bg-gray-900">
+            <FilmIcon />
+          </div>
+        ) : null}
+        <div className="pointer-events-none absolute left-2 top-2 z-10 flex items-center gap-1.5 rounded-md bg-black/70 px-2 py-1 text-xs font-semibold text-white backdrop-blur-sm">
+          <Icon icon="mdi:calendar-blank-outline" className="shrink-0 text-purple-300" />
+          {title}
+          {subtitle && <span className="font-normal text-white/70">&middot; {subtitle}</span>}
+        </div>
+      </div>
+      <div className="flex flex-1 flex-col items-center p-4">
+        <CardInfoButtons {...props} />
+      </div>
+    </article>
+  );
+}
+
+function CustomCard(props) {
+  return props.primary ? <PrimaryCard {...props} /> : <SubCard {...props} />;
 }
 
 export default CustomCard;

--- a/src/components/ui/InfoBanner/index.tsx
+++ b/src/components/ui/InfoBanner/index.tsx
@@ -16,18 +16,30 @@ function InfoBanner({
   title,
   description,
   image,
-  styles,
+  styles = '',
   icon,
-  bgColor = 'from-blue-700 via-blue-700 to-blue-900 dark:from-blue-500  dark:to-blue-700',
-  titleColor = 'text-purple-700 dark:text-purple-500',
+  bgColor,
+  titleColor = 'text-white',
   marginHeight = 'mt-8 lg:mt-16',
 }: BannerProps): JSX.Element {
+  // A gradient's `background-image` always paints over a flat `background-color`,
+  // so a caller-supplied `bg-*` in `styles` would silently lose to this default —
+  // only fall back to the brand gradient when the caller hasn't set their own background.
+  // (Previously this default also omitted `bg-gradient-to-r`, so `from-*`/`via-*`/`to-*`
+  // never rendered as a gradient at all — the banner had no visible background.)
+  const hasCustomBackground = /(^|\s)bg-/.test(styles);
+  const resolvedBgColor =
+    bgColor ??
+    (hasCustomBackground ? '' : 'bg-gradient-to-r from-blue-500 to-purple-700 dark:from-blue-700 dark:to-purple-900');
+
   return (
-    <section className={`${styles} ${bgColor} ${marginHeight} mx-auto w-full`}>
-      <div className="mx-auto flex max-w-3xl flex-wrap items-center justify-center gap-4 py-4 md:py-8 lg:gap-8 xl:max-w-fit">
-        <div>
+    <section className={`${styles} ${resolvedBgColor} ${marginHeight} mx-auto w-full shadow-inner`}>
+      <div className="container mx-auto flex max-w-3xl flex-col items-center justify-center gap-6 py-10 text-center md:py-14 lg:flex-row lg:gap-8 lg:text-start">
+        <div className="shrink-0">
           {icon ? (
-            <Icon icon={icon} className="text-4xl text-white dark:text-gray-50" />
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white/10 ring-1 ring-white/20">
+              <Icon icon={icon} className="text-4xl text-white" />
+            </div>
           ) : image ? (
             <img src={image.src} alt={image.alt} />
           ) : (
@@ -36,12 +48,12 @@ function InfoBanner({
         </div>
 
         {title ? (
-          <div className="mx-auto text-center md:text-start lg:pl-4">
-            <h3 className={`mx-auto mb-4 text-3xl font-bold ${titleColor}`}>{title}</h3>
-            <Markdown text={description} styles="mx-auto max-w-4xl leading-relaxed text-gray-700" />
+          <div>
+            <h3 className={`mb-2 text-3xl font-bold ${titleColor}`}>{title}</h3>
+            <Markdown text={description} styles="leading-relaxed text-blue-50" />
           </div>
         ) : (
-          <Markdown text={description} styles="mx-auto leading-relaxed" />
+          <Markdown text={description} styles="leading-relaxed text-blue-50" />
         )}
       </div>
     </section>

--- a/src/components/ui/InfoBox/index.tsx
+++ b/src/components/ui/InfoBox/index.tsx
@@ -3,15 +3,18 @@ import React from 'react';
 type BoxProps = {
   title: string;
   text: string;
-  darkBg?: string;
 };
 
-function InfoBox({ title, text, darkBg = 'dark:bg-purple-900' }: BoxProps): JSX.Element {
+function InfoBox({ title, text }: BoxProps): JSX.Element {
   return (
-    <aside
-      className={`rounded-lg bg-aqua ${darkBg} max-w-lg px-6 py-8 text-gray-700 shadow-xl dark:shadow-md dark:shadow-gray-900`}>
-      <h4 className="mx-auto mb-2 max-w-md font-bold dark:text-gray-50">{title}</h4>
-      <p className="mx-auto max-w-md dark:text-gray-100">{text}</p>
+    <aside className="flex max-w-lg items-start gap-3 rounded-xl bg-blue-50 p-5 dark:bg-blue-500/10">
+      <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-blue-500 text-xs font-bold text-white">
+        i
+      </span>
+      <div>
+        <h4 className="mb-1 font-bold text-gray-900 dark:text-gray-50">{title}</h4>
+        <p className="text-gray-700 dark:text-gray-100">{text}</p>
+      </div>
     </aside>
   );
 }

--- a/src/components/ui/SmallCard/index.tsx
+++ b/src/components/ui/SmallCard/index.tsx
@@ -1,19 +1,26 @@
 import React from 'react';
 import Button from '@site/src/components/utilities/Button';
 import Markdown from '@site/src/components/utilities/Markdown';
+import { Icon } from '@iconify/react';
 
 type SmallCardProps = Card & {
   button: Button;
+  icon?: string;
 };
 
 function SmallCard(props: SmallCardProps) {
-  const { title, subtitle, button } = props;
+  const { title, subtitle, button, icon } = props;
 
   return (
-    <article className=" my-4 flex max-w-xs flex-col justify-between">
-      <h4 className="text-gray-700">{title}</h4>
-      <Markdown text={subtitle} styles="mb-4 mt-2 w-[198px] md:w-64" />
-      <Button outline={true} as="link" {...button} />
+    <article className="group flex flex-col justify-between gap-4 rounded-xl border border-gray-100 bg-gray-50 p-4 transition duration-150 ease-linear hover:-translate-y-1 hover:shadow-md dark:border-white/10 dark:bg-white/5">
+      <div>
+        <div className="mb-2 flex items-center gap-2">
+          {icon && <Icon icon={icon} className="text-lg text-purple-700 dark:text-purple-500" />}
+          <h4 className="text-gray-900 dark:text-gray-50">{title}</h4>
+        </div>
+        <Markdown text={subtitle} styles="text-sm text-gray-700 dark:text-gray-300" />
+      </div>
+      <Button outline={true} as="link" colors="w-full justify-center" {...button} />
     </article>
   );
 }

--- a/src/components/ui/Testimonial/index.tsx
+++ b/src/components/ui/Testimonial/index.tsx
@@ -12,32 +12,62 @@ type TestimonialProps = {
   featuredlink?: string;
 };
 
+const AVATAR_FALLBACK =
+  "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'%3E%3Ccircle cx='24' cy='24' r='24' fill='%23A5A0B1'/%3E%3Ccircle cx='24' cy='19' r='8' fill='%23F7F6F9'/%3E%3Cpath d='M8 42c2-10 10-16 16-16s14 6 16 16' fill='%23F7F6F9'/%3E%3C/svg%3E";
+
 function Testimonial(props: TestimonialProps) {
   return (
-    <article className="flex flex-col mx-2 my-4 max-w-sm rounded-sm bg-white p-4 shadow-lg dark:bg-gray-900">
-      <div className="flex items-center gap-3 mb-4">
-        <div className="m-2">
-          <div className="flex items-center gap-2">
-            <h3 className="text-lg font-bold">{props.name}</h3>
-            <Icon icon={`logos:${props.social}`} className="text-2xl" />
-          </div>
-          <a href={props.path} className=" text-gray-700 dark:text-gray-100 dark:hover:text-purple-900 no-underline hover:no-underline hover:bg-purple-300">
+    <article className="group relative mx-2 my-4 flex w-80 shrink-0 snap-start flex-col overflow-hidden rounded-2xl border border-gray-100 bg-white/90 p-6 shadow-sm backdrop-blur-sm transition-all duration-300 ease-out hover:-translate-y-1 hover:border-purple-300 hover:shadow-xl hover:shadow-purple-500/10 dark:border-white/10 dark:bg-gray-900/90 dark:hover:border-purple-500/30 dark:hover:shadow-purple-900/20">
+      <Icon
+        icon="mdi:format-quote-close"
+        className="pointer-events-none absolute -right-3 -top-3 text-8xl text-purple-50 transition-colors duration-300 group-hover:text-purple-100 dark:text-white/5 dark:group-hover:text-white/10"
+      />
+      <div className="relative z-10 mb-4 flex items-center gap-3">
+        <div className="relative shrink-0">
+          <img
+            src={props.avatar}
+            alt="user avatar"
+            className="h-12 w-12 rounded-full object-cover shadow-sm ring-2 ring-white dark:ring-gray-700"
+            onError={e => {
+              e.currentTarget.onerror = null;
+              e.currentTarget.src = AVATAR_FALLBACK;
+            }}
+          />
+          <span className="absolute -bottom-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-white shadow-sm ring-1 ring-gray-100 dark:bg-gray-700 dark:ring-white/10">
+            <Icon icon={`logos:${props.social}`} className="text-[0.65rem]" />
+          </span>
+        </div>
+        <div className="min-w-0">
+          <h3 className="truncate text-base font-bold leading-tight text-gray-900 dark:text-white">{props.name}</h3>
+          <a
+            href={props.path}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="block truncate text-sm text-gray-500 no-underline transition duration-150 ease-linear hover:text-purple-700 hover:no-underline dark:text-gray-300 dark:hover:text-purple-300">
             {props.handle}
           </a>
         </div>
-        <div className="order-first">
-          <img src={`${props.avatar}`} alt="user avatar" className="h-fit w-fit max-w-16 max-h-16 rounded-full" />
-        </div>
       </div>
-      <div className="mt-2 mb-4 truncate">
-        <p className="whitespace-normal text-gray-900 dark:text-gray-300 leading-snug mb-2">{props.description}</p>
-        {props.featuredlink && <a target="_blank" href={props.featuredlink}>{props.featuredlink}</a>}
-      </div>
-      <div className="mt-auto self-start text-gray-300 dark:text-gray-700 italic">
-        <a href={props.path} className="text-gray-300 dark:text-gray-700 dark:hover:text-gray-700 no-underline hover:no-underline hover:bg-purple-300">
-          {props.date}
+      <p className="relative z-10 mb-3 line-clamp-4 flex-1 text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+        {props.description}
+      </p>
+      {props.featuredlink && (
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href={props.featuredlink}
+          className="relative z-10 mb-3 truncate rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700 no-underline hover:no-underline dark:bg-blue-500/10 dark:text-blue-300">
+          {props.featuredlink}
         </a>
-      </div>
+      )}
+      <a
+        href={props.path}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="relative z-10 mt-auto flex items-center gap-1 self-start border-t border-gray-100 pt-3 text-xs font-medium text-gray-500 no-underline transition duration-150 ease-linear hover:text-purple-700 hover:no-underline dark:border-white/10 dark:text-gray-500 dark:hover:text-purple-300">
+        <Icon icon="mdi:calendar-blank-outline" className="text-sm" />
+        {props.date}
+      </a>
     </article>
   );
 }

--- a/src/components/ui/ThumbCard/index.tsx
+++ b/src/components/ui/ThumbCard/index.tsx
@@ -6,7 +6,7 @@ type ThumbCardProps = Card & {
 
 function ThumbCard({ title, subtitle, image }: ThumbCardProps): JSX.Element {
   return (
-    <article className="flex max-w-xs flex-col items-center justify-center rounded-md p-6 shadow-md lg:m-4">
+    <article className="flex max-w-xs flex-col items-center justify-center rounded-md border border-gray-100 p-6 shadow-md transition duration-200 hover:-translate-y-1 hover:shadow-lg dark:border-gray-700 lg:m-4">
       <h3 className="hidden">{title}</h3>
       <p className="w-48 text-center">{subtitle}</p>
       <img src={image.path} alt={image.alt} className="order-first my-8 h-20" />

--- a/src/components/ui/VideoEmbed/index.tsx
+++ b/src/components/ui/VideoEmbed/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+function VideoEmbed({ url, title, className = '' }: { url: string; title: string; className?: string }) {
+  return (
+    <div className={`aspect-video w-full overflow-hidden rounded-lg bg-black ${className}`}>
+      <iframe
+        src={url}
+        title={`${title} recording`}
+        className="h-full w-full"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+      />
+    </div>
+  );
+}
+
+export default VideoEmbed;

--- a/src/components/utilities/Button/index.tsx
+++ b/src/components/utilities/Button/index.tsx
@@ -9,37 +9,34 @@ type ButtonProps = Button & {
 
 function Button({ as = 'link', outline, colors, icon, text, method, path }: ButtonProps) {
   const baseStyles =
-    'text-xl h-fit my-2 block max-w-fit cursor-pointer rounded-md px-6 py-2 font-semibold transition duration-150 ease-in-out hover:no-underline hover:shadow-md whitespace-nowrap';
+    'inline-flex items-center justify-center gap-2 my-2 max-w-fit cursor-pointer whitespace-nowrap rounded-md px-6 py-2.5 text-base font-semibold no-underline transition duration-150 ease-in-out hover:no-underline active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900';
   const solidColors =
-    'bg-purple-700 dark:bg-purple-900 text-white dark:text-white hover:bg-purple-900 no-underline hover:no-underline dark:hover:text-gray-50 dark:hover:bg-purple-700 hover:text-white';
+    'border border-transparent bg-purple-700 text-white shadow-sm hover:bg-purple-900 hover:shadow-md hover:text-white dark:bg-purple-700 dark:hover:bg-purple-500';
   const outlineColors =
-    'no-underline outline dark:bg-white dark:text-purple-700 text-purple-700 dark:text-purple-900 dark:hover:bg-purple-900 dark:hover:text-white';
+    'border-2 border-purple-700 bg-transparent text-purple-700 hover:bg-purple-700 hover:text-white dark:border-purple-500 dark:text-purple-300 dark:hover:bg-purple-500 dark:hover:text-white';
   /* Set Colors */
-  const variantStyles = outline ? ` ${outlineColors} ${colors}` : `${solidColors} ${colors}`;
+  const variantStyles = `${outline ? outlineColors : solidColors} ${colors ?? ''}`;
+  const className = `${baseStyles} ${variantStyles}`;
+
+  const content = !icon ? (
+    <span>{text}</span>
+  ) : (
+    <span className="flex items-center gap-2">
+      {text} <Icon icon={icon} />
+    </span>
+  );
 
   /** Render the component with style variations */
   if (as === 'button') {
     return (
-      <button onClick={method} className={`${baseStyles} ${variantStyles}`}>
-        {!icon ? (
-          <span>{text}</span>
-        ) : (
-          <span className="flex items-center gap-2">
-            {text} <Icon icon={icon} />
-          </span>
-        )}
+      <button type="button" onClick={method} className={className}>
+        {content}
       </button>
     );
   }
   return (
-    <a href={path} className={`${baseStyles} ${variantStyles}`}>
-      {!icon ? (
-        <span>{text}</span>
-      ) : (
-        <span className="flex items-center gap-2">
-          {text} <Icon icon={icon} />
-        </span>
-      )}
+    <a href={path} className={className}>
+      {content}
     </a>
   );
 }

--- a/src/components/utilities/DropDown/index.tsx
+++ b/src/components/utilities/DropDown/index.tsx
@@ -6,7 +6,7 @@ import './styles.css';
 type DropdownProps = {
   text: string;
   options: any[];
-  dropdownRef: React.MutableRefObject<undefined>;
+  dropdownRef: React.RefObject<HTMLDivElement | null>;
 };
 
 function toggleDropdown(ref, handler) {
@@ -31,19 +31,23 @@ function Dropdown(props: DropdownProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   toggleDropdown(dropdownRef, () => setIsOpen(false));
   return (
-    <div ref={dropdownRef}>
-      <div
+    <div ref={dropdownRef} className="w-full">
+      <button
+        type="button"
         data-dropdown-toggle="dropdown"
         onClick={() => setIsOpen(prev => !prev)}
-        className="my-2 flex cursor-pointer items-center gap-1 py-2 pl-12 font-bold text-purple-700 dark:text-purple-500">
+        aria-expanded={isOpen}
+        className="my-2 flex w-full cursor-pointer items-center gap-2 py-2 pl-12 font-bold text-purple-700 transition duration-150 ease-linear hover:text-purple-900 dark:text-purple-500 dark:hover:text-purple-300">
         <div className={`transition duration-150 ease-linear ${isOpen && 'rotate-90'}`}>
           <Icon icon="bi:caret-right-square-fill" />
         </div>
         <span>{props.text}</span>
-      </div>
-      <div className="dropdown-options absolute mt-2 flex flex-col overflow-y-auto overflow-x-hidden shadow-md scrollbar-thin scrollbar-track-gray-100 scrollbar-thumb-gray-300 dark:bg-gray-900 md:max-h-full lg:max-h-96">
-        {isOpen && props?.options.map(option => option)}
-      </div>
+      </button>
+      {isOpen && (
+        <div className="dropdown-options flex max-h-96 flex-col divide-y divide-gray-100 overflow-y-auto overflow-x-hidden rounded-xl border border-gray-100 bg-white shadow-md scrollbar-thin scrollbar-track-gray-100 scrollbar-thumb-gray-300 dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-900">
+          {props?.options.map(option => option)}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/utilities/DropDown/styles.css
+++ b/src/components/utilities/DropDown/styles.css
@@ -1,3 +1,3 @@
 .dropdown-options {
-  width: 40%;
+  width: 100%;
 }

--- a/src/components/utilities/DropdownButton/index.tsx
+++ b/src/components/utilities/DropdownButton/index.tsx
@@ -4,7 +4,11 @@ import { Icon } from '@iconify/react';
 type DropdownProps = {
   text: string;
   option: React.ReactNode;
+  className?: string;
 };
+
+const defaultButtonClassName =
+  'my-2 inline-flex items-center gap-2 rounded-md border border-transparent bg-white px-6 py-2.5 text-base font-semibold text-purple-700 shadow-sm transition duration-150 ease-in-out hover:bg-purple-50 hover:shadow-md active:scale-[0.98] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 dark:text-purple-900 dark:hover:bg-white/90 dark:focus-visible:ring-offset-gray-900';
 
 function toggleDropdown(ref, handler) {
   useEffect(() => {
@@ -24,20 +28,27 @@ function toggleDropdown(ref, handler) {
 }
 
 function DropdownButton(props: DropdownProps) {
-  const dropdownRef = useRef();
+  const dropdownRef = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState<boolean>(false);
   toggleDropdown(dropdownRef, () => setIsOpen(false));
   return (
-    <div ref={dropdownRef}>
+    <div ref={dropdownRef} className="relative">
       <button
-        data-dropdown-toggle="dropdown"
+        type="button"
+        aria-haspopup="true"
+        aria-expanded={isOpen}
         onClick={() => setIsOpen(prev => !prev)}
-        className="my-2 flex items-center gap-2 rounded-md bg-white px-4 py-2 font-bold text-purple-700 transition duration-150 ease-linear hover:bg-purple-700 hover:text-white focus:shadow-md dark:text-purple-900 dark:hover:text-white">
+        className={props.className ?? defaultButtonClassName}>
         <span>{props.text}</span>
-        <Icon icon="ion:caret-down-outline" />
+        <Icon
+          icon="ion:caret-down-outline"
+          className={`transition-transform duration-150 ${isOpen ? 'rotate-180' : ''}`}
+        />
       </button>
       {isOpen && (
-        <div className="absolute mt-2 max-w-fit rounded-md bg-white shadow-md dark:bg-gray-900">{props.option}</div>
+        <div className="absolute z-20 mt-2 min-w-[16rem] max-w-fit overflow-hidden rounded-md border border-gray-100 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-900">
+          {props.option}
+        </div>
       )}
     </div>
   );

--- a/src/components/utilities/IconLink/index.tsx
+++ b/src/components/utilities/IconLink/index.tsx
@@ -5,22 +5,48 @@ export type IconLinkProps = Link & {
   textLogo?: string;
   icon?: string;
   image?: Image;
+  invertInDark?: boolean;
+  description?: string;
+  linkText?: string;
+  accentColor?: string;
 };
 
-function IconLink({ text, path, icon, image, textLogo }: IconLinkProps) {
+function IconLink({
+  text,
+  path,
+  icon,
+  image,
+  textLogo,
+  invertInDark,
+  description,
+  linkText,
+  accentColor = 'text-blue-700 dark:text-blue-500',
+}: IconLinkProps) {
   return (
-    <a href={path} className="mx-auto flex flex-col items-center text-center">
-      <div className="max-w-fit rounded-full bg-white p-8 shadow-sm  dark:bg-gray-900">
+    <a
+      href={path}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group relative flex h-full flex-col items-center gap-4 overflow-hidden rounded-2xl border border-gray-100 bg-white p-6 text-center no-underline shadow-sm transition-all duration-300 ease-out hover:-translate-y-1.5 hover:border-purple-300 hover:no-underline hover:shadow-xl hover:shadow-purple-500/10 dark:border-white/10 dark:bg-gray-900 dark:hover:border-purple-500/30 dark:hover:shadow-purple-900/20">
+      <span className="pointer-events-none absolute inset-x-0 top-0 h-1 origin-left scale-x-0 bg-gradient-to-r from-blue-500 via-purple-500 to-purple-700 transition-transform duration-300 ease-out group-hover:scale-x-100" />
+      <div
+        className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl bg-gray-50 text-3xl shadow-sm ring-1 ring-black/5 transition-transform duration-300 ease-out group-hover:scale-110 dark:bg-white/5 dark:ring-white/10 ${accentColor}`}>
         {icon ? (
-          <Icon icon={icon} className="text-5xl" />
+          <Icon icon={icon} className="text-3xl" />
         ) : textLogo ? (
-          <span className="block py-2 font-display text-4xl font-extrabold">{textLogo}</span>
+          <span className="font-display text-lg font-extrabold text-gray-900 dark:text-gray-50">{textLogo}</span>
         ) : (
-          <img src={image.path} alt={image.alt} className="w-16" />
+          <img src={image.path} alt={image.alt} className={`w-9 ${invertInDark ? 'dark:invert' : ''}`} />
         )}
       </div>
-      <span className="underline-offset-6 duration-149 mt-4 block text-blue-700 underline transition ease-linear hover:text-blue-900">
-        {text}
+      <div className="flex flex-1 flex-col items-center">
+        <h3 className="font-bold text-gray-900 dark:text-gray-50">{text}</h3>
+        {description && <p className="mt-1 text-sm text-gray-500 dark:text-gray-300">{description}</p>}
+      </div>
+      <span
+        className={`mt-auto inline-flex items-center gap-1.5 font-semibold transition-all duration-200 ease-out group-hover:gap-2.5 ${accentColor}`}>
+        {linkText ?? text}
+        <Icon icon="mdi:arrow-right" className="text-base transition-transform duration-200 ease-out" />
       </span>
     </a>
   );

--- a/src/components/utilities/Link/index.tsx
+++ b/src/components/utilities/Link/index.tsx
@@ -13,8 +13,8 @@ function Link({
   fontSize,
   textColor = 'text-blue-700 dark:text-blue-500',
   hoverColor = 'hover:text-purple-700 hover:dark:text-purple-700',
-  underline = 'underline underline-offset-4',
-  target = '_self'
+  underline = 'no-underline hover:underline underline-offset-4',
+  target = '_self',
 }: LinkProps): JSX.Element {
   return (
     <a

--- a/src/components/utilities/PlayOnScroll/index.tsx
+++ b/src/components/utilities/PlayOnScroll/index.tsx
@@ -1,45 +1,43 @@
 import React, { useRef, useEffect } from 'react';
 
 interface VideoProps {
-    url: string;
-    vidFormat?: string;
-    styles?: string;
-    posterImg?: string;
-  }
+  url: string;
+  vidFormat?: string;
+  styles?: string;
+  posterImg?: string;
+}
 
-const PlayOnScroll: React.FC = (props: VideoProps) => {
-    const videoRef = useRef<HTMLVideoElement>(null);
-  
-    useEffect(() => {
-      const handleScroll = () => {
-        if (videoRef.current) {
-          const rect = videoRef.current.getBoundingClientRect();
-          const isFullyVisible = rect.top >= 0 && rect.bottom <= window.innerHeight;
-          
-          if (isFullyVisible) {
-            videoRef.current.play();
-          } else {
-            videoRef.current.pause();
-          }
+const PlayOnScroll: React.FC<VideoProps> = props => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          video.play().catch(() => {});
+        } else {
+          video.pause();
         }
-      };
-  
-      window.addEventListener('scroll', handleScroll);
-      
-      return () => {
-        window.removeEventListener('scroll', handleScroll);
-      };
-    }, []);
-  
-    return (
-      <div>
-        <video className={props.styles} ref={videoRef} poster={props.posterImg} autoPlay>
-          <source src={props.url} type={props.vidFormat} />
-          {/* Add additional source elements for different video formats if needed */}
-          Your browser does not support the video tag.
-        </video>
-      </div>
+      },
+      { threshold: 0.25 },
     );
-  };
-  
-  export default PlayOnScroll;
+
+    observer.observe(video);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div>
+      <video className={props.styles} ref={videoRef} poster={props.posterImg} muted playsInline loop>
+        <source src={props.url} type={props.vidFormat} />
+        {/* Add additional source elements for different video formats if needed */}
+        Your browser does not support the video tag.
+      </video>
+    </div>
+  );
+};
+
+export default PlayOnScroll;

--- a/src/components/utilities/TerminalCard/index.tsx
+++ b/src/components/utilities/TerminalCard/index.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+interface TerminalCardProps {
+  children: string;
+  label?: string;
+}
+
+function TerminalCard({ children, label = 'TERMINAL' }: TerminalCardProps): JSX.Element {
+  const [copied, setCopied] = useState(false);
+  const code = children.trim();
+  const lines = code.split('\n');
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="overflow-hidden rounded-xl bg-gray-900 shadow-md dark:bg-black">
+      <div className="flex items-center justify-between border-b border-white/10 px-5 py-3">
+        <span className="text-xs font-bold tracking-wide text-purple-300">{label}</span>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="rounded-md bg-white/10 px-3 py-1 text-xs font-semibold text-white transition duration-150 ease-linear hover:bg-white/20">
+          {copied ? 'Copied!' : 'Copy'}
+        </button>
+      </div>
+      <div className="overflow-x-auto px-5 py-4">
+        <pre className="w-max min-w-full !bg-transparent font-mono text-sm leading-relaxed">
+          {lines.map((line, index) => {
+            const trimmed = line.trimStart();
+            const isCommand = trimmed.startsWith('$');
+            if (line === '') {
+              return <div key={index}>&nbsp;</div>;
+            }
+            return (
+              <div key={index} className={isCommand ? 'text-white' : 'text-gray-300'}>
+                {isCommand ? (
+                  <>
+                    <span className="text-blue-500">$</span>
+                    {trimmed.slice(1)}
+                  </>
+                ) : (
+                  line
+                )}
+              </div>
+            );
+          })}
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+export default TerminalCard;

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -7,6 +7,10 @@
 @import 'fonts/source-code-pro.css';
 
 :root {
+  /* Matches the navbar's actual rendered height (see `.navbar--fixed-top`
+     below) — components like the docs sidebar and TOC read this variable
+     to position themselves just below the navbar. */
+  --ifm-navbar-height: 5.5rem;
   --ifm-color-primary: #892ca0;
   --ifm-color-primary-darkest: #5f246b;
   --ifm-color-primary-light: #bd58dd;
@@ -32,43 +36,88 @@
   @apply mt-10;
 }
 
+/* Docs sidebar + TOC polish: rounded hover/active pills instead of Infima's
+   plain color-only states, matching the treatment built for the Nextra
+   docs sidebar on the Next.js branch. */
+.theme-doc-sidebar-container {
+  @apply border-r border-gray-300 dark:border-gray-700;
+}
+
+.table-of-contents {
+  @apply border-l border-gray-300 dark:border-gray-700;
+}
+
+.menu__link,
+.table-of-contents__link {
+  border-radius: 0.25rem;
+  transition:
+    background-color 150ms ease-linear,
+    color 150ms ease-linear;
+}
+
+.menu__link:hover,
+.table-of-contents__link:hover {
+  @apply bg-gray-100 text-gray-900 dark:bg-purple-500/10 dark:text-gray-50;
+}
+
+.menu__link--active:not(.menu__link--sublist),
+.table-of-contents__link--active {
+  @apply bg-purple-100 font-semibold text-purple-700 dark:bg-purple-500/10 dark:text-purple-300;
+}
+
 .navbar__title {
   font-family: Montserrat;
   font-weight: 500 !important;
-  /* font-size: 200%; */
   padding: 8px 0px;
   letter-spacing: -1.5px !important;
   font-kerning: normal !important;
 }
 
 #__docusaurus > nav > div.navbar__inner > div:nth-child(1) > a > b {
-  font-size: xxx-large;
+  font-size: x-large;
   line-height: 2rem;
 }
 
 .navbar__logo {
-  height: 6.25rem;
+  height: 4.25rem;
 }
 
+/* Full-bleed gradient navbar, sticky at the top of the page. */
 .navbar {
   box-shadow: none;
-  @apply bg-gradient-to-r from-blue-500  to-purple-700 dark:from-blue-700 dark:to-purple-900;
+  @apply bg-gradient-to-r from-blue-500 to-purple-700 dark:from-blue-700 dark:to-purple-900;
 }
 
 .navbar--fixed-top {
-  height: 7rem;
+  min-height: 5.5rem;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
 }
 
 .navbar__title,
-.navbar__link,
-.clean-btn {
+.navbar__link {
   @apply text-white dark:text-gray-50;
-  font-size: x-large;
+  font-size: 1.125rem;
+}
+
+.navbar .clean-btn {
+  @apply text-white dark:text-gray-50;
+  transition: color 150ms ease-linear;
+}
+
+.navbar .clean-btn:hover {
+  @apply text-purple-300;
 }
 
 .navbar-sidebar__brand .navbar__title,
 .navbar-sidebar__brand .clean-btn {
   @apply text-gray-900 dark:text-gray-50;
+}
+
+/* The docs sidebar renders its own fallback logo to cover for
+   `hideOnScroll` hiding the main navbar — that duplicates the real navbar
+   right above it, so hide it. */
+.theme-doc-sidebar-container [class*='sidebarLogo_'] {
+  display: none !important;
 }
 
 .navbar__link svg,
@@ -77,9 +126,24 @@
   margin-left: 12px;
 }
 
+/* Give navbar links breathing room — they sit flush with zero gap by
+   default, so the hover pill (background + lift + shadow) of one link
+   touches and visually overlaps the next link's hover pill. */
+.navbar__items {
+  @apply gap-1;
+}
+
 .navbar__link,
 .navbar__brand {
-  @apply no-underline transition duration-150 ease-linear hover:text-purple-300;
+  @apply rounded-md px-3 py-2 font-medium tracking-wide no-underline transition duration-200 ease-linear hover:-translate-y-0.5 hover:bg-purple-500 hover:text-white hover:shadow-md;
+}
+
+.navbar__brand {
+  @apply rounded-md px-0 py-0 hover:translate-y-0 hover:bg-transparent hover:text-purple-300 hover:shadow-none;
+}
+
+.navbar__link--active {
+  @apply bg-purple-500 text-white shadow-md;
 }
 
 .footer {
@@ -90,15 +154,15 @@
   @apply text-blue-50 no-underline hover:text-blue-300 dark:hover:text-blue-500;
 }
 
-.footer__copyright p{
+.footer__copyright p {
   display: block;
   font-size: medium;
   padding: 0px;
 }
 
-.footer__copyright a{
+.footer__copyright a {
   font-size: medium;
-  @apply text-blue-300 hover:text-blue-500
+  @apply text-blue-300 hover:text-blue-500;
 }
 
 .menu a {
@@ -109,8 +173,109 @@
   @apply no-underline;
 }
 
-.navbar__link--active {
-  @apply text-purple-300 underline dark:text-purple-300 dark:underline;
+/* Back-to-top button (Docusaurus renders it on every page, docs included,
+   once scrolled past its threshold): brand gradient FAB instead of
+   Infima's plain gray circle, so it's easy to spot in a corner. */
+.theme-back-to-top-button {
+  right: 1.5rem;
+  bottom: 1.5rem;
+  width: 3.25rem;
+  height: 3.25rem;
+  @apply bg-gradient-to-br from-blue-500 to-purple-700 shadow-lg transition-all duration-200 ease-out hover:-translate-y-1 hover:shadow-xl dark:from-blue-700 dark:to-purple-900;
+}
+
+.theme-back-to-top-button::after {
+  @apply bg-white;
+}
+
+/* ------------------------------------ */
+/* Docs content polish (code, tables,   */
+/* admonitions, blockquotes, pagination)*/
+/* ------------------------------------ */
+
+/* Code blocks: rounded card treatment instead of Infima's flat square box. */
+.markdown pre {
+  border-radius: 0.75rem !important;
+  @apply border border-gray-100 shadow-sm dark:border-white/10;
+}
+
+/* Inline code: tinted pill instead of the plain gray box. */
+.markdown :not(pre) > code {
+  @apply rounded-md border border-purple-100 bg-purple-50 px-1.5 py-0.5 text-purple-700 dark:border-purple-500/20 dark:bg-purple-500/10 dark:text-purple-300;
+}
+
+/* Tables: rounded container, tinted header, zebra striping. */
+.markdown table {
+  border-collapse: separate;
+  border-spacing: 0;
+  overflow: hidden;
+  border-radius: 0.75rem;
+  @apply w-full border border-gray-100 shadow-sm dark:border-white/10;
+}
+
+.markdown th {
+  @apply bg-purple-50 text-sm font-bold uppercase tracking-wide text-purple-700 dark:bg-purple-500/10 dark:text-purple-300;
+}
+
+.markdown tbody tr:nth-child(even) td {
+  @apply bg-gray-50 dark:bg-white/5;
+}
+
+.markdown tbody tr:hover td {
+  @apply bg-purple-50/60 dark:bg-purple-500/10;
+}
+
+.markdown td,
+.markdown th {
+  transition: background-color 150ms ease-linear;
+}
+
+/* Blockquotes: accent border + soft tint instead of plain indented text. */
+.markdown blockquote {
+  @apply rounded-r-lg border-l-4 border-purple-300 bg-purple-50/50 py-2 pl-4 italic text-gray-700 dark:border-purple-500/40 dark:bg-purple-500/5 dark:text-gray-300;
+}
+
+/* Admonitions (:::note/tip/info/caution/danger) and <details> callouts,
+   which Infima renders with the same `.alert` classes: rounded card with a
+   colored accent edge instead of a flat solid-color box. */
+.alert {
+  border-radius: 0.75rem !important;
+  border-width: 0 0 0 4px !important;
+  @apply shadow-sm;
+}
+
+.alert--info,
+.alert--note {
+  @apply border-blue-500 bg-blue-50 dark:border-blue-500 dark:bg-blue-500/10;
+}
+
+.alert--tip,
+.alert--success {
+  @apply border-purple-500 bg-purple-50 dark:border-purple-300 dark:bg-purple-500/10;
+}
+
+.alert--caution,
+.alert--warning {
+  @apply border-[#c2860a] bg-[#fdf6e8] dark:border-[#e0ac2b] dark:bg-[#e0ac2b]/10;
+}
+
+.alert--danger {
+  @apply border-[#dc2626] bg-[#fef2f2] dark:border-[#f87171] dark:bg-[#dc2626]/10;
+}
+
+/* Pagination nav (prev/next doc links): interactive cards with hover lift,
+   matching the treatment used for cards across the rest of the site. */
+.pagination-nav__link {
+  border-radius: 1rem !important;
+  @apply border border-gray-100 shadow-sm transition-all duration-300 ease-out hover:-translate-y-1 hover:border-purple-300 hover:shadow-xl hover:shadow-purple-500/10 dark:border-white/10 dark:hover:border-purple-500/30 dark:hover:shadow-purple-900/20;
+}
+
+.pagination-nav__sublabel {
+  @apply text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-500;
+}
+
+.pagination-nav__label {
+  @apply text-purple-700 dark:text-purple-300;
 }
 
 /* ------------------ */
@@ -120,7 +285,7 @@
   /* headings */
   h1,
   h2,
-  h2>a,
+  h2 > a,
   h3,
   h4,
   h5 {
@@ -145,7 +310,7 @@
   }
 
   a {
-    @apply font-text text-lg text-blue-500 underline underline-offset-4 transition duration-150 ease-linear hover:opacity-90 dark:text-blue-500 dark:hover:text-blue-700 lg:text-xl;
+    @apply font-text text-lg text-blue-500 no-underline underline-offset-4 transition duration-150 ease-linear hover:text-blue-700 hover:underline dark:text-blue-500 dark:hover:text-blue-300 lg:text-xl;
   }
 
   /* headings size and weight */

--- a/src/hooks/useBlogPosts.ts
+++ b/src/hooks/useBlogPosts.ts
@@ -30,7 +30,7 @@ export const useBlogPosts = (limit: number = 4): UseBlogPostsReturn => {
     const fetchData = async () => {
       try {
         const rawData = await fetch(
-          `https://blog.podman.io/wp-json/wp/v2/posts?per_page=${limit}&_fields=id,author_info,title,wbDate,jetpack_featured_media_url,link,excerpt`,
+          `https://blog.podman.io/wp-json/wp/v2/posts?per_page=${limit}&_fields=id,author,author_info,title,wbDate,jetpack_featured_media_url,link,excerpt`,
         );
         const jsonData = await rawData.json();
         setData(jsonData);

--- a/src/lib/detectOperatingSystem.ts
+++ b/src/lib/detectOperatingSystem.ts
@@ -1,0 +1,23 @@
+export type OperatingSystemId = 'windows' | 'mac' | 'linux';
+
+export function detectOperatingSystem(): OperatingSystemId {
+  const userAgent = window.navigator.userAgent.toLowerCase().split(' ');
+  if (userAgent.find(item => item.includes('windows'))) {
+    return 'windows';
+  } else if (userAgent.find(item => item.includes('macintosh'))) {
+    return 'mac';
+  }
+  return 'linux';
+}
+
+export const osLabels: Record<OperatingSystemId, string> = {
+  windows: 'Windows',
+  mac: 'macOS',
+  linux: 'Linux',
+};
+
+export const osIcons: Record<OperatingSystemId, string> = {
+  windows: 'fa-brands:windows',
+  mac: 'fa-brands:apple',
+  linux: 'fa-brands:linux',
+};

--- a/src/lib/meetings.js
+++ b/src/lib/meetings.js
@@ -1,0 +1,82 @@
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+
+// Recordings are almost always YouTube (see extractRecordingLink), but a handful
+// link to BlueJeans/Drive instead — those fall back to a plain external link.
+function getYouTubeEmbedUrl(url) {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname === 'youtu.be') {
+      const id = parsed.pathname.slice(1);
+      return id ? `https://www.youtube.com/embed/${id}` : undefined;
+    }
+    if (parsed.hostname.endsWith('youtube.com')) {
+      const id = parsed.searchParams.get('v');
+      return id ? `https://www.youtube.com/embed/${id}` : undefined;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function extractFirstHeading(body, level) {
+  const re = new RegExp(`^${level}\\s+(.+)$`, 'm');
+  const match = body.match(re);
+  return match ? match[1].trim() : undefined;
+}
+
+function extractRecordingLink(body) {
+  const lines = body.split('\n');
+  const linkLine = lines.find(line => /video|recording|bluejeans/i.test(line) && /\[[^\]]*\]\([^)]+\)/.test(line));
+  const match = linkLine && linkLine.match(/\[[^\]]*\]\(([^)]+)\)/);
+  return match ? match[1] : undefined;
+}
+
+function getMeetingNotes(notesDir) {
+  const slugs = fs
+    .readdirSync(notesDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .filter(name => /^\d{4}-\d{2}-\d{2}$/.test(name));
+
+  const notes = slugs
+    .map(slug => {
+      const filePath = path.join(notesDir, slug, 'index.md');
+      if (!fs.existsSync(filePath)) return null;
+
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      const { data: frontmatter, content } = matter(raw);
+
+      const title = frontmatter.title || extractFirstHeading(content, '#') || 'Podman Community Meeting';
+      const dateHeading = extractFirstHeading(content, '##') || slug;
+      const displayDate = dateHeading.split(/\d{2}:\d{2}/)[0].trim();
+
+      // Jekyll leftovers like `# {{ page.title }}` render literally; swap in the resolved title instead.
+      const cleanedContent = content.replace(/^#\s+\{\{.*\}\}\s*$/m, `# ${title}`);
+
+      const recordingLink = extractRecordingLink(content);
+
+      return {
+        slug,
+        date: slug,
+        displayDate,
+        title,
+        isCabal: title.toLowerCase().includes('cabal'),
+        recordingLink,
+        recordingEmbedUrl: getYouTubeEmbedUrl(recordingLink),
+        content: cleanedContent,
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.date.localeCompare(a.date));
+
+  return {
+    community: notes.filter(note => !note.isCabal),
+    cabal: notes.filter(note => note.isCabal),
+  };
+}
+
+module.exports = { getMeetingNotes, getYouTubeEmbedUrl };

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -10,7 +10,6 @@ import CommunityMeetingsCardGrid from '@site/src/components/layout/CommunityMeet
 import SmallCard from '@site/src/components/ui/SmallCard';
 import DateTimeBox from '@site/src/components/content/DateTimeBox';
 import InfoBox from '@site/src/components/ui/InfoBox';
-import InfoBanner from '@site/src/components/ui/InfoBanner';
 import IconLink from '@site/src/components/utilities/IconLink';
 import Button from '@site/src/components/utilities/Button';
 import DropdownButton from '@site/src/components/utilities/DropdownButton';
@@ -18,6 +17,44 @@ import DropdownButton from '@site/src/components/utilities/DropdownButton';
 import { header, communityChat, communityMeetings, mailingList, submittingIssues } from '@site/static/data/community';
 
 /* PAGE COMPONENTS */
+const NoticeCard = ({
+  icon,
+  image,
+  text,
+  accent = 'purple',
+}: {
+  icon?: string;
+  image?: { src: string; alt: string };
+  text: string;
+  accent?: 'purple' | 'blue';
+}): JSX.Element => {
+  const accentStyles =
+    accent === 'blue'
+      ? 'border-blue-500 bg-blue-50 dark:bg-blue-500/10'
+      : 'border-purple-500 bg-purple-50 dark:bg-purple-500/10';
+  return (
+    <div className="container">
+      <div
+        className={`mx-auto flex max-w-3xl flex-col items-center gap-4 rounded-2xl border-l-4 p-6 text-center shadow-sm sm:flex-row sm:text-left lg:p-8 ${accentStyles}`}>
+        <div className="shrink-0">
+          {icon ? (
+            <div
+              className={`flex h-12 w-12 items-center justify-center rounded-full text-2xl text-white ${accent === 'blue' ? 'bg-blue-600' : 'bg-purple-700'}`}>
+              <Icon icon={icon} />
+            </div>
+          ) : (
+            image && <img src={image.src} alt={image.alt} className="h-12 w-12 object-contain" />
+          )}
+        </div>
+        <Markdown
+          text={text}
+          styles="leading-relaxed text-gray-700 dark:text-gray-100 [&_a]:font-semibold [&_a]:text-purple-700 dark:[&_a]:text-purple-400"
+        />
+      </div>
+    </div>
+  );
+};
+
 const CommunityLinks = () => {
   const links = communityChat.links.map(x => x);
   return (
@@ -246,22 +283,18 @@ function Community() {
   return (
     <Layout>
       <PageHeader title={header.title} description={header.subtitle} />
-      <InfoBanner
-        description={header.banner.text}
-        icon={header.banner.icon}
-        styles="bg-purple-500 dark:bg-purple-700 text-white"
-      />
+      <div className="pb-8 lg:pb-12">
+        <NoticeCard icon={header.banner.icon} text={header.banner.text} accent="purple" />
+      </div>
       <CommunityChatSection />
       <CommunityMeetingSection />
-      <InfoBanner
-        description="**Searching for Podman Desktop Community Meetings?** [Click Here](https://podman-desktop.io/community#community-events) or visit the [official website](https://podman-desktop.io) to learn more."
-        image={{
-          src: '/logos/optimized/podman-desktop-logo-200w-198h.webp',
-          alt: 'Podman Desktop Logo',
-        }}
-        styles="bg-purple-700 dark:bg-purple-900 text-white [&_img]:w-16 [&_img]:h-16  [&_a:hover]:text-purple-300"
-        marginHeight="mt-8 lg:mt-16"
-      />
+      <div className="py-8 lg:py-12">
+        <NoticeCard
+          image={{ src: '/logos/optimized/podman-desktop-logo-200w-198h.webp', alt: 'Podman Desktop Logo' }}
+          text="**Searching for Podman Desktop Community Meetings?** [Click Here](https://podman-desktop.io/community#community-events) or visit the [official website](https://podman-desktop.io) to learn more."
+          accent="blue"
+        />
+      </div>
       <MailingListSection />
       <SubmitIssuesSection />
       <ThankYouSection />

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -14,7 +14,6 @@ import InfoBanner from '@site/src/components/ui/InfoBanner';
 import IconLink from '@site/src/components/utilities/IconLink';
 import Button from '@site/src/components/utilities/Button';
 import DropdownButton from '@site/src/components/utilities/DropdownButton';
-import WaveBorder from '@site/src/components/shapes/WaveBorder';
 /* PAGE DATA */
 import { header, communityChat, communityMeetings, mailingList, submittingIssues } from '@site/static/data/community';
 
@@ -22,11 +21,11 @@ import { header, communityChat, communityMeetings, mailingList, submittingIssues
 const CommunityLinks = () => {
   const links = communityChat.links.map(x => x);
   return (
-    <ul className="mb-12 flex flex-wrap items-end justify-around gap-8 lg:gap-16">
+    <ul className="mx-auto grid w-full grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
       {links.map((link, index) => {
         return (
-          <li key={index}>
-            <IconLink {...link} />
+          <li key={index} className="h-full">
+            <IconLink {...link} accentColor="text-purple-700 dark:text-purple-300" />
           </li>
         );
       })}
@@ -36,39 +35,43 @@ const CommunityLinks = () => {
 
 const CommunityChatSection = (): JSX.Element => {
   return (
-    <section className="bg-gray-50 dark:bg-gradient-to-t dark:from-gray-700 dark:via-gray-900 dark:to-gray-900 ">
-      <SectionHeader textGradient={true} title={communityChat.title} />
-      <div className="mx-4 mt-8 flex flex-wrap justify-around gap-4 sm:mx-8 lg:mx-auto lg:mt-16 lg:max-w-6xl">
-        <div className="">
-          <p className="max-w-sm text-center text-gray-700 md:max-w-md md:text-start lg:max-w-xl">
-            {communityChat.subtitle}
-          </p>
-        </div>
+    <section className="relative overflow-hidden bg-gradient-to-b from-gray-50 to-white pb-12 dark:from-gray-700 dark:to-gray-900 lg:pb-20">
+      <div className="pointer-events-none absolute -top-20 left-1/4 h-72 w-72 rounded-full bg-blue-300/20 blur-3xl dark:bg-blue-700/10" />
+      <div className="pointer-events-none absolute -top-10 right-1/4 h-72 w-72 rounded-full bg-purple-300/20 blur-3xl dark:bg-purple-700/10" />
+      <SectionHeader
+        textGradient={true}
+        title={communityChat.title}
+        description={communityChat.subtitle}
+        textGradientStops="from-blue-700 to-purple-700 dark:from-blue-500 dark:to-purple-500"
+      />
+      <div className="relative mx-4 mt-8 flex flex-col items-center justify-center gap-10 sm:mx-8 lg:mx-auto lg:mt-16 lg:max-w-6xl">
+        <CommunityLinks />
         <DateTimeBox />
       </div>
-      <div className="container pt-12 lg:pt-20">
-        <CommunityLinks />
-      </div>
-      <WaveBorder />
     </section>
   );
 };
 
 const CommunityMeetingSection = (): JSX.Element => {
   return (
-    <section className="bg-gradient-to-b from-white via-gray-50 to-gray-100 pb-8 dark:from-gray-900 dark:to-gray-900">
+    <section className="bg-gradient-to-b from-white via-gray-50 to-gray-100 pb-8 dark:from-gray-900 dark:via-gray-900 dark:to-gray-900">
       <div className="container flex flex-col">
         <SectionHeader
           title={communityMeetings.title}
-          description={communityMeetings.subtitle}
           textGradientStops="from-purple-500 to-purple-700 dark:text-purple-500"
           textGradient={true}
         />
-        <img
-          src={communityMeetings.image.path}
-          alt={communityMeetings.image.alt}
-          className="order-first mx-auto object-cover lg:max-w-lg"
-        />
+        <div className="mx-auto mb-12 flex flex-col items-center gap-8 lg:mb-16 lg:flex-row lg:items-center lg:gap-12">
+          <img
+            src={communityMeetings.image.path}
+            alt={communityMeetings.image.alt}
+            className="w-full max-w-lg shrink-0 rounded-2xl object-cover shadow-md lg:w-1/2"
+          />
+          <Markdown
+            text={communityMeetings.subtitle}
+            styles="max-w-2xl text-center leading-relaxed text-gray-700 dark:text-gray-100 lg:text-left"
+          />
+        </div>
         <CommunityMeetingsCardGrid cards={communityMeetings.cards} />
       </div>
     </section>
@@ -77,42 +80,51 @@ const CommunityMeetingSection = (): JSX.Element => {
 
 const MailingListSection = (): JSX.Element => {
   return (
-    <section>
-      <div className="container grid gap-4 lg:grid-cols-2">
+    <section className="pb-16 lg:pb-20">
+      <div className="container grid gap-10 lg:grid-cols-2">
         <SectionHeader
           title={mailingList.title}
           description={mailingList.subtitle}
           layout="col-span-full"
           textColor="dark:text-blue-700"
         />
-        <section className="container mb-8">
-          <h3 className="mb-2 font-medium text-purple-700 dark:text-purple-500">{mailingList.browseInfo.title}</h3>
-          <Markdown text={mailingList.browseInfo.subtitle} styles="max-w-prose" />
-        </section>
-        <section className="container mb-8">
-          <h3 className="mb-2 font-medium text-purple-700 dark:text-purple-500">{mailingList.subscribeInfo.title}</h3>
-          <Markdown text={mailingList.subscribeInfo.subtitle} styles="max-w-prose " />
-          <div className="flex flex-wrap gap-6">
-            {mailingList.subscribeInfo.options.map((card, index) => {
-              return <SmallCard {...card} key={index} />;
-            })}
+        <div className="flex flex-col gap-6">
+          <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900 lg:p-8">
+            <div className="mb-3 flex items-center gap-3">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-blue-100 text-blue-700 dark:bg-blue-500/10 dark:text-blue-500">
+                <Icon icon="mdi:email-search-outline" className="text-xl" />
+              </span>
+              <h3 className="font-medium text-purple-700 dark:text-purple-500">{mailingList.browseInfo.title}</h3>
+            </div>
+            <Markdown text={mailingList.browseInfo.subtitle} styles="max-w-prose" />
           </div>
-          <div className="my-4 max-w-prose">
-            <Markdown text={mailingList.subscribeInfo.description} />
+
+          <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900 lg:p-8">
+            <div className="mb-3 flex items-center gap-3">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-purple-100 text-purple-700 dark:bg-purple-500/10 dark:text-purple-500">
+                <Icon icon="mdi:email-fast-outline" className="text-xl" />
+              </span>
+              <h3 className="font-medium text-purple-700 dark:text-purple-500">{mailingList.subscribeInfo.title}</h3>
+            </div>
+            <Markdown text={mailingList.subscribeInfo.subtitle} styles="max-w-prose" />
+            <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+              {mailingList.subscribeInfo.options.map((card, index) => {
+                return <SmallCard {...card} key={index} />;
+              })}
+            </div>
+            <div className="mt-6 max-w-prose border-t border-gray-100 pt-4 text-xs text-gray-500 dark:border-white/10 dark:text-gray-300">
+              <Markdown text={mailingList.subscribeInfo.description} />
+            </div>
           </div>
-        </section>
-        <section className="mb-8 lg:col-start-2 lg:row-span-2 lg:row-start-2">
-          <div>
-            <img
-              src={mailingList.extraInfo.image.path}
-              alt={mailingList.extraInfo.image.alt}
-              className="w-full  object-cover"
-            />
-          </div>
-          <div className="ml-8 xl:ml-10">
-            <InfoBox title={mailingList.extraInfo.note.title} text={mailingList.extraInfo.note.text} />
-          </div>
-        </section>
+        </div>
+        <div className="flex flex-col gap-6 rounded-2xl border border-gray-100 bg-white p-6 shadow-md dark:border-gray-700 dark:bg-gray-900">
+          <img
+            src={mailingList.extraInfo.image.path}
+            alt={mailingList.extraInfo.image.alt}
+            className="w-full rounded-xl object-cover"
+          />
+          <InfoBox title={mailingList.extraInfo.note.title} text={mailingList.extraInfo.note.text} />
+        </div>
       </div>
     </section>
   );
@@ -124,8 +136,10 @@ const DropdownContent = (props): JSX.Element => {
       <ul>
         {props.map((link, index) => {
           return (
-            <li className="my-2 rounded-md px-2 transition duration-150 ease-linear hover:bg-purple-700 hover:text-white">
-              <a href={link.path} className=" w-full hover:text-white hover:no-underline">
+            <li
+              key={index}
+              className="my-2 rounded-md px-2 transition duration-150 ease-linear hover:bg-purple-700 hover:text-white">
+              <a href={link.path} className="w-full hover:text-white hover:no-underline">
                 {link.text}
               </a>
             </li>
@@ -138,12 +152,12 @@ const DropdownContent = (props): JSX.Element => {
 
 const IssuesSection = () => {
   return (
-    <section className="max-w-lg rounded-md bg-white px-10 pt-10 shadow-lg dark:bg-gray-900">
+    <section className="max-w-lg rounded-2xl border border-gray-100 bg-white px-10 pt-10 shadow-md ring-1 ring-black/5 transition duration-200 hover:-translate-y-1 hover:shadow-xl dark:border-gray-700 dark:bg-gray-900 dark:ring-white/5">
       <header className="mb-10">
         <h3 className="mb-4 text-center text-blue-700 dark:text-blue-500">{submittingIssues[1].title}</h3>
-        <div className="bg-blue-100/25 px-3 py-2">
-          <p className="flex items-center gap-2 rounded-md">
-            <Icon icon="fa-solid:exclamation-circle" className="text-purple-700" />
+        <div className="rounded-md bg-blue-100/25 px-3 py-2 dark:bg-blue-500/10">
+          <p className="flex items-center gap-2 rounded-md dark:text-gray-100">
+            <Icon icon="fa-solid:exclamation-circle" className="text-purple-700 dark:text-purple-500" />
             <span>{submittingIssues[1].subtitle}</span>
           </p>
         </div>
@@ -155,10 +169,18 @@ const IssuesSection = () => {
               <Markdown text={section.text} />
               <ul className="mb-8 ml-5 mt-4 list-disc">
                 {section.checkList.map((item, index) => {
-                  return <li key={index}>{item}</li>;
+                  return (
+                    <li key={index} className="text-gray-900 dark:text-gray-100">
+                      {item}
+                    </li>
+                  );
                 })}
               </ul>
-              <DropdownButton text={section.button.text} option={DropdownContent(section.button.links)} />
+              <DropdownButton
+                text={section.button.text}
+                option={DropdownContent(section.button.links)}
+                className="my-2 inline-flex items-center gap-2 rounded-md border-2 border-purple-700 bg-transparent px-6 py-2.5 text-base font-semibold text-purple-700 transition duration-150 ease-in-out hover:bg-purple-700 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 focus-visible:ring-offset-2 active:scale-[0.98] dark:border-purple-500 dark:text-purple-300 dark:hover:bg-purple-500 dark:hover:text-white dark:focus-visible:ring-offset-gray-900"
+              />
             </div>
           );
         })}
@@ -169,7 +191,7 @@ const IssuesSection = () => {
 
 const PullRequestSection = () => {
   return (
-    <section className="max-w-lg rounded-md bg-white p-10 shadow-lg dark:bg-gray-900">
+    <section className="max-w-lg rounded-2xl border border-gray-100 bg-white p-10 shadow-md ring-1 ring-black/5 transition duration-200 hover:-translate-y-1 hover:shadow-xl dark:border-gray-700 dark:bg-gray-900 dark:ring-white/5">
       <header className="mx-auto mb-10">
         <h3 className="mb-3 text-center text-blue-700 dark:text-blue-500">{submittingIssues[2].title}</h3>
         <Markdown text={submittingIssues[2].subtitle} />
@@ -184,10 +206,19 @@ const PullRequestSection = () => {
         })}
         <ul className="my-4 ml-5 list-disc">
           {submittingIssues[2].checkList.map((item, index) => {
-            return <li key={index}>{item}</li>;
+            return (
+              <li key={index} className="text-gray-900 dark:text-gray-100">
+                {item}
+              </li>
+            );
           })}
         </ul>
-        <Button as="link" outline={true} text={submittingIssues[2].button.text} />
+        <Button
+          as="link"
+          outline={true}
+          path={submittingIssues[2].button.path}
+          text={submittingIssues[2].button.text}
+        />
       </div>
     </section>
   );
@@ -195,14 +226,14 @@ const PullRequestSection = () => {
 
 const SubmitIssuesSection = () => {
   return (
-    <section className="bg-gradient-to-b from-gray-50 to-gray-100 dark:from-gray-900 dark:via-blue-900 dark:to-purple-900">
+    <section className="bg-gradient-to-b from-gray-50 to-gray-100 pb-16 pt-8 dark:from-gray-900 dark:via-blue-900 dark:to-purple-900 lg:pb-20 lg:pt-12">
       <SectionHeader
         title={submittingIssues[0].title}
         description={submittingIssues[0].subtitle}
         textGradientStops="from-purple-500 to-purple-700 dark:text-blue-700"
         textGradient={true}
       />
-      <div className="mx-auto mb-20 mt-16 flex flex-wrap justify-center gap-20 px-8 lg:container">
+      <div className="mx-auto mt-16 flex flex-wrap justify-center gap-10 px-8 lg:container lg:gap-20">
         <IssuesSection />
         <PullRequestSection />
       </div>
@@ -225,12 +256,12 @@ function Community() {
       <InfoBanner
         description="**Searching for Podman Desktop Community Meetings?** [Click Here](https://podman-desktop.io/community#community-events) or visit the [official website](https://podman-desktop.io) to learn more."
         image={{
-          src: "logos/optimized/podman-desktop-logo-200w-198h.webp",
-          alt: "Podman Desktop Logo"
+          src: '/logos/optimized/podman-desktop-logo-200w-198h.webp',
+          alt: 'Podman Desktop Logo',
         }}
-        styles="bg-purple-700 dark:bg-purple-900 text-white [&_img]:w-16 [&_img]:h-16  [&_a]:underline [&_a:hover]:text-purple-300"
+        styles="bg-purple-700 dark:bg-purple-900 text-white [&_img]:w-16 [&_img]:h-16  [&_a:hover]:text-purple-300"
         marginHeight="mt-8 lg:mt-16"
-      /> 
+      />
       <MailingListSection />
       <SubmitIssuesSection />
       <ThankYouSection />

--- a/src/pages/downloads.tsx
+++ b/src/pages/downloads.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import PageHeader from '@site/src/components/layout/PageHeader';
+import DownloadsGrid from '@site/src/components/content/DownloadsGrid';
+
+function Downloads() {
+  return (
+    <Layout title="Downloads" description="Download Podman CLI and Podman Desktop for Windows, macOS, and Linux.">
+      <PageHeader
+        title="Downloads"
+        description="Get **Podman CLI** and **Podman Desktop** for Windows, macOS, and Linux. We automatically detect your operating system and highlight the best option for you below."
+      />
+      <DownloadsGrid />
+    </Layout>
+  );
+}
+
+export default Downloads;

--- a/src/pages/features.tsx
+++ b/src/pages/features.tsx
@@ -7,26 +7,51 @@ import PageHeader from '@site/src/components/layout/PageHeader';
 import SectionHeader from '@site/src/components/layout/SectionHeader';
 import ColoringBookSection from '@site/src/components/content/ColoringBookSection';
 import FeaturesCarousel from '@site/src/components/content/FeaturesCarousel';
-import BlogArticlesList from '@site/src/components/content/BlogArticlesList';
 /* PAGE DATA */
 import { header, knowPodman, learnMore } from '@site/static/data/features';
 import PlayOnScroll from '@site/src/components/utilities/PlayOnScroll';
-import BasicResourcesBox from '@site/src/components/content/BasicResourcesBox';
 
 /* PAGE COMPONENTS */
+const knowPodmanMeta = [
+  { icon: 'mdi:book-open-page-variant', cta: { text: 'Docs', path: '/docs' } },
+  { icon: 'mdi:account-group', cta: { text: 'Join Us', path: '/community' } },
+  {
+    icon: 'mdi:help-circle',
+    cta: {
+      text: 'Troubleshooting',
+      path: 'https://github.com/containers/podman/blob/main/troubleshooting.md',
+    },
+  },
+];
+
 function GetToKnowPodmanSection() {
   return (
     <section className="mb-8 mt-4 lg:mt-8 xl:mb-12">
       <SectionHeader title={knowPodman.title} textColor="text-blue-700 dark:text-blue-500" />
-      <div className="container flex flex-wrap justify-center gap-4 lg:gap-8">
+      <div className="container grid grid-cols-1 gap-12 sm:grid-cols-3 lg:gap-16">
         {knowPodman.cards.map((card, index) => {
+          const meta = knowPodmanMeta[index];
           return (
-            <article key={index} className="mt-2 flex flex-col justify-start rounded-md p-4 text-center lg:mt-4">
-              <div>
-                <h3 className="mb-4 font-medium dark:text-blue-500 xl:mb-6">{card.title}</h3>
-                <Markdown text={card.description} styles="max-w-xs" />
+            <article key={index} className="flex h-full flex-col items-center rounded-md p-4 text-center">
+              <div className="flex h-48 w-48 items-center justify-center rounded-full bg-purple-50 dark:bg-purple-500/10">
+                <img src={card.image.path} alt={card.image.alt} className="h-36 w-auto object-contain" />
               </div>
-              <img src={card.image.path} alt={card.image.alt} className="order-first my-2 h-52 w-auto object-contain" />
+              {meta?.icon && (
+                <span className="mt-4 flex h-12 w-12 items-center justify-center rounded-full bg-purple-50 text-2xl text-purple-700 dark:bg-purple-500/10 dark:text-purple-300">
+                  <Icon icon={meta.icon} />
+                </span>
+              )}
+              <h3 className="mt-4 font-medium dark:text-blue-500">{card.title}</h3>
+              <span className="mt-2 h-0.5 w-8 rounded-full bg-purple-500" />
+              <Markdown text={card.description} styles="mt-4 max-w-xs text-sm" />
+              {meta?.cta && (
+                <a
+                  href={meta.cta.path}
+                  className="mt-auto inline-flex items-center gap-1.5 pt-4 font-semibold text-purple-700 no-underline hover:text-purple-900 dark:text-purple-300 dark:hover:text-purple-100">
+                  {meta.cta.text}
+                  <Icon icon="mdi:arrow-right" />
+                </a>
+              )}
             </article>
           );
         })}
@@ -37,50 +62,79 @@ function GetToKnowPodmanSection() {
 
 const PodmanDesktopSection = () => {
   return (
-    <section className="bg-gradient-to-b from-gray-50 to-gray-100 pb-5 dark:bg-gray-900 dark:from-gray-700/25 dark:to-gray-900">
-      <div className="align-center container flex justify-center">
-        <div className="flex-row content-center">
-          <h2 className="content-center">
-            <a className="hover:no-underline hover:text-white active:text-white visited:text-white dark:hover:text-white dark:active:text-white dark:visited:text-white text-4xl mb-5 px-5  bg-blue-500 no-underline text-white dark:bg-blue-700 dark:text-white" href="https://podman-desktop.io">Podman Desktop</a>
-          </h2>
-        </div>
-      </div>
-      <div className="container flex flex-col md:flex-row items-center">
-        <div id="imgdiv" className="mx-auto w-full md:w-auto">
-          <img id="pdlogo" className="mx-auto" src="logos/optimized/podman-desktop-logo-200w-198h.webp" />
-        </div>
-        <div className="md:w-1/2 xl:w-3/4">
-          <p className="my-8 align-middle text-2xl leading-relaxed">
-            <a className="font-semibold hover:text-purple-500 text-purple-900 no-underline text-2xl leading-releaxed" href="https://podman-desktop.io">Podman Desktop</a> is Podman's graphical application that makes it easy to install and work with Podman (and
-            other container engines) on Windows, MacOS, and Linux.
-          </p>
+    <section className="py-10">
+      <div className="container">
+        <div className="relative flex flex-col items-center gap-8 overflow-hidden rounded-3xl border border-gray-100 bg-gray-50 p-8 text-center shadow-sm dark:border-white/10 dark:bg-gray-900 sm:flex-row sm:p-12 sm:text-left">
+          <div className="pointer-events-none absolute -left-10 -top-16 h-56 w-56 rounded-full bg-blue-300/50 blur-3xl dark:bg-blue-700/20" />
+          <div className="pointer-events-none absolute -bottom-20 right-10 h-64 w-64 rounded-full bg-purple-300/50 blur-3xl dark:bg-purple-700/20" />
+          <img
+            className="relative h-28 w-28 shrink-0 sm:h-32 sm:w-32"
+            src="/logos/optimized/podman-desktop-logo-200w-198h.webp"
+            alt="Podman Desktop logo"
+          />
+          <div className="relative flex flex-col items-center gap-4 sm:items-start">
+            <h3 className="text-blue-700 dark:text-blue-500">Podman Desktop</h3>
+            <p className="max-w-2xl text-lg leading-relaxed text-gray-700 dark:text-gray-100">
+              Podman Desktop is Podman's graphical application that makes it easy to install and work with Podman (and
+              other container engines) on Windows, MacOS, and Linux.
+            </p>
+            <a
+              href="https://podman-desktop.io"
+              className="inline-flex items-center gap-1.5 rounded-md bg-purple-700 px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition duration-150 ease-linear hover:bg-purple-900 hover:no-underline dark:bg-purple-700 dark:hover:bg-purple-500">
+              Explore Podman Desktop
+              <Icon icon="mdi:arrow-right" />
+            </a>
+          </div>
         </div>
       </div>
     </section>
   );
 };
 
+const SectionEyebrow = ({ icon, text }: { icon: string; text: string }) => (
+  <span className="mb-3 inline-flex items-center gap-1.5 rounded-full bg-purple-50 px-3 py-1 text-xs font-semibold text-purple-700 dark:bg-purple-500/10 dark:text-purple-300">
+    <Icon icon={icon} />
+    {text}
+  </span>
+);
+
+const FeatureList = ({ items }: { items: string[] }) => (
+  <ul className="space-y-3">
+    {items.map(item => (
+      <li key={item} className="flex items-start gap-2.5">
+        <Icon icon="mdi:check-circle" className="mt-0.5 shrink-0 text-lg text-purple-700 dark:text-purple-300" />
+        <span className="text-gray-700 dark:text-gray-100">{item}</span>
+      </li>
+    ))}
+  </ul>
+);
+
 const ManageContainersUISection = () => {
   return (
-    <section className="xl:py-16 xl:flex xl:flex-row-reverse bg-gradient-to-b from-purple-100 to-purple-300 dark:from-black dark:to-gray-900">
-      <div className="flex-1 w-full md:my-16 md:w-4/5 md:mx-auto lg:w-full xl:my-16">
-        <PlayOnScroll vidFormat="video/mp4" url="video/ui/containers.mp4" posterImg="images/optimized/ui-screens/ui-manage-containers.webp" styles="rounded-lg w-full lg:w-3/4 lg:mx-auto xl:mr-0 xl:w-full max-w-[1200px] items-center md:rounded-3xl bg-cover md:bg-contain xl:rounded-r-none" />
+    <section className="flex flex-col items-center gap-8 py-12 sm:flex-row-reverse sm:gap-12 sm:py-16">
+      <div className="relative w-full sm:w-2/5 sm:flex-none">
+        <div className="pointer-events-none absolute -right-8 -top-10 h-40 w-48 rounded-[45%] bg-purple-300/55 blur-2xl dark:bg-purple-900/35" />
+        <div className="pointer-events-none absolute -bottom-10 -left-6 h-32 w-40 rounded-[40%] bg-blue-300/45 blur-2xl dark:bg-blue-900/30" />
+        <PlayOnScroll
+          vidFormat="video/mp4"
+          url="/video/ui/containers.mp4"
+          posterImg="/images/optimized/ui-screens/ui-manage-containers.webp"
+          styles="relative mx-auto w-full max-w-[560px] rounded-lg bg-cover object-contain md:rounded-3xl"
+        />
       </div>
-      <div className="flex flex-1 my-16 md:my-none">
-        <div className="flex-row px-16 xl:p-16 x2l:my-16 md:w-4/5 md:mx-auto">
-          <h3 className="mb-5 dark:text-white">Manage containers (not just Podman.)</h3>
-          <p className="mb-3 dark:text-white">
-            Podman Desktop allows you to list, view, and manage containers from multiple supported container
-            engines* in a single unified view.
-          </p>
-          <p className="mb-3 dark:text-white">
-            Gain easy access to a shell inside the container, logs, and basic controls.
-          </p>
-          <em className="mt-10 block dark:text-white">
-            * Supported engines and orchestrators include Podman, Docker, Lima, kind, Red Hat OpenShift, Red Hat 
-            OpenShift Developer Sandbox.
-          </em>
-        </div>
+      <div className="w-full px-6 sm:flex-1 sm:px-16">
+        <SectionEyebrow icon="mdi:cube-outline" text="Container Management" />
+        <h3 className="mb-4 text-blue-700 dark:text-blue-500">Manage every container, not just Podman's.</h3>
+        <FeatureList
+          items={[
+            'List, inspect, and control containers from every supported engine* in a single unified view.',
+            'Jump into a live shell, tail logs, and run everyday lifecycle actions without touching a terminal.',
+          ]}
+        />
+        <p className="mt-6 text-sm italic text-gray-500 dark:text-gray-300">
+          * Supported engines and orchestrators include Podman, Docker, Lima, kind, Red Hat OpenShift, Red Hat OpenShift
+          Developer Sandbox.
+        </p>
       </div>
     </section>
   );
@@ -88,81 +142,97 @@ const ManageContainersUISection = () => {
 
 const BuildImagesUISection = () => {
   return (
-  <section className="xl:py-16 xl:flex xl:flex-row bg-gradient-to-b from-purple-100 to-purple-300 dark:from-black dark:to-gray-900 xl:dark:from-gray-900 xl:dark:to-black">
-    <div className="flex-1 w-full md:my-16 md:w-4/5 md:mx-auto lg:w-full xl:my-16">
-      <PlayOnScroll vidFormat="video/mp4" url="video/ui/images.mp4" posterImg="images/optimized/ui-screens/ui-buildimage.webp" styles="rounded-lg w-full lg:w-3/4 lg:mx-auto xl:ml-0 xl:w-full max-w-[1200px] items-center md:rounded-3xl bg-cover md:bg-contain xl:rounded-l-none" />
-    </div>
-    <div className="flex flex-1 my-16 md:my-none">
-      <div className="flex-row px-16 xl:p-16 x2l:my-16 md:w-4/5 md:mx-auto">
-        <h3 className="mb-5 dark:text-white">Build, pull, and push images.</h3>
-        <p className="mb-3 dark:text-white">
-          Build containers from a Dockerfile / Containerfile, or pull images from remote repositories to run.
-        </p>
-        <p className="mb-3 dark:text-white">
-          Manage accounts for and push your images to multiple container registries.
-        </p>
+    <section className="flex flex-col items-center gap-8 py-12 sm:flex-row sm:gap-12 sm:py-16">
+      <div className="relative w-full sm:w-2/5 sm:flex-none">
+        <div className="pointer-events-none absolute -left-10 -top-8 h-36 w-44 rounded-[40%] bg-blue-300/55 blur-2xl dark:bg-blue-900/35" />
+        <div className="pointer-events-none absolute -bottom-8 -right-6 h-36 w-36 rounded-[45%] bg-purple-300/45 blur-2xl dark:bg-purple-900/30" />
+        <PlayOnScroll
+          vidFormat="video/mp4"
+          url="/video/ui/images.mp4"
+          posterImg="/images/optimized/ui-screens/ui-buildimage.webp"
+          styles="relative mx-auto w-full max-w-[560px] rounded-lg bg-cover object-contain md:rounded-3xl"
+        />
       </div>
-    </div>
-  </section>
+      <div className="w-full px-6 sm:flex-1 sm:px-16">
+        <SectionEyebrow icon="mdi:package-variant-closed" text="Image Building" />
+        <h3 className="mb-4 text-blue-700 dark:text-blue-500">Build, pull, and push images with ease.</h3>
+        <FeatureList
+          items={[
+            'Build containers straight from a Dockerfile or Containerfile, or pull ready-made images from any remote registry.',
+            'Manage accounts for every registry and push your images wherever they need to go.',
+          ]}
+        />
+      </div>
+    </section>
   );
 };
 
 const CreatePodsUISection = () => {
   return (
-    <section className="xl:py-16 xl:flex xl:flex-row-reverse bg-gradient-to-b from-purple-100 to-purple-300 dark:from-black dark:to-gray-900">
-    <div className="flex-1 w-full md:my-16 md:w-4/5 md:mx-auto lg:w-full xl:my-16">
-      <PlayOnScroll vidFormat="video/mp4" url="video/ui/podify.mp4" posterImg="images/optimized/ui-screens/ui-podify.webp" styles="rounded-lg w-full lg:w-3/4 lg:mx-auto xl:mr-0 xl:w-full max-w-[1200px] items-center md:rounded-3xl bg-cover md:bg-contain xl:rounded-r-none" />
-    </div>
-    <div className="flex flex-1 my-16 md:my-none">
-      <div className="flex-row px-16 xl:p-16 x2l:my-16 md:w-4/5 md:mx-auto">
-        <h3 className="mb-5 dark:text-white">Podify containers into pods.</h3>
-        <p className="mb-3 dark:text-white">
-          Create pods by selecting containers to run together. View unified logs for your pods and inspect the
-          containers inside each.
-        </p>
-        <p className="mb-3 dark:text-white">
-        Play Kubernetes YAML locally, without Kubernetes, and generate Kubernetes YAML from Pods.
-        </p>
+    <section className="flex flex-col items-center gap-8 py-12 sm:flex-row-reverse sm:gap-12 sm:py-16">
+      <div className="relative w-full sm:w-2/5 sm:flex-none">
+        <div className="pointer-events-none absolute -bottom-10 -right-6 h-40 w-48 rounded-[42%] bg-purple-300/55 blur-2xl dark:bg-purple-900/35" />
+        <div className="pointer-events-none absolute -left-8 -top-6 h-32 w-36 rounded-[38%] bg-blue-300/45 blur-2xl dark:bg-blue-900/30" />
+        <PlayOnScroll
+          vidFormat="video/mp4"
+          url="/video/ui/podify.mp4"
+          posterImg="/images/optimized/ui-screens/ui-podify.webp"
+          styles="relative mx-auto w-full max-w-[560px] rounded-lg bg-cover object-contain md:rounded-3xl"
+        />
       </div>
-    </div>
-  </section>
+      <div className="w-full px-6 sm:flex-1 sm:px-16">
+        <SectionEyebrow icon="mdi:hexagon-multiple-outline" text="Pod Orchestration" />
+        <h3 className="mb-4 text-blue-700 dark:text-blue-500">Podify containers into pods.</h3>
+        <FeatureList
+          items={[
+            'Group containers into pods with a click, then view unified logs and inspect every container inside.',
+            'Play Kubernetes YAML locally without a cluster, or generate YAML straight from your pods.',
+          ]}
+        />
+      </div>
+    </section>
   );
 };
 
 const DeployToKubernetesUISection = () => {
   return (
-  <section className="xl:py-16 md:pb-32 xl:flex xl:flex-row bg-gradient-to-b from-purple-100 to-purple-300  dark:from-black dark:to-gray-900 xl:dark:from-gray-900 xl:dark:to-black">
-    <div className="flex-1 w-full md:my-16 md:w-4/5 md:mx-auto lg:w-full xl:my-16">
-      <PlayOnScroll vidFormat="video/mp4" url="video/ui/kubernetes.mp4" posterImg="images/optimized/ui-screens/ui-k8sdeploy.webp" styles="rounded-lg w-full lg:w-3/4 lg:mx-auto xl:ml-0 xl:w-full max-w-[1200px] items-center md:rounded-3xl bg-cover md:bg-contain xl:rounded-l-none" />
-    </div>
-    <div className="flex flex-1 my-16 md:my-none">
-      <div className="flex-row px-16 xl:p-16 x2l:my-16 md:w-4/5 md:mx-auto">
-        <h3 className="mb-5 dark:text-white">Deploy to Kubernetes.</h3>
-        <p className="mb-3 dark:text-white">
-          Deploy pods from Podman Desktop to local or remote Kubernetes contexts using automatically-generated
-          YAML config.
-        </p>
+    <section className="flex flex-col items-center gap-8 py-12 sm:flex-row sm:gap-12 sm:py-16">
+      <div className="relative w-full sm:w-2/5 sm:flex-none">
+        <div className="pointer-events-none absolute -bottom-8 -left-6 h-36 w-44 rounded-[44%] bg-blue-300/55 blur-2xl dark:bg-blue-900/35" />
+        <div className="pointer-events-none absolute -right-10 -top-8 h-32 w-36 rounded-[36%] bg-purple-300/45 blur-2xl dark:bg-purple-900/30" />
+        <PlayOnScroll
+          vidFormat="video/mp4"
+          url="/video/ui/kubernetes.mp4"
+          posterImg="/images/optimized/ui-screens/ui-k8sdeploy.webp"
+          styles="relative mx-auto w-full max-w-[560px] rounded-lg bg-cover object-contain md:rounded-3xl"
+        />
       </div>
-    </div>
-  </section>
+      <div className="w-full px-6 sm:flex-1 sm:px-16">
+        <SectionEyebrow icon="mdi:kubernetes" text="Kubernetes Deploy" />
+        <h3 className="mb-4 text-blue-700 dark:text-blue-500">Deploy straight to Kubernetes.</h3>
+        <FeatureList
+          items={[
+            'Push pods from Podman Desktop to local or remote Kubernetes contexts using automatically-generated YAML.',
+          ]}
+        />
+      </div>
+    </section>
   );
 };
 
 const PodmanCLISection = () => {
   return (
-    <section className="bg-gradient-to-b from-gray-50 to-gray-100  pb-5 dark:from-gray-700/25  dark:to-gray-900">
-      <div className="align-center container mb-8 flex justify-center xl:mb-20">
-        <div className="flex-row content-center">
-          <h2 className="mb-5 content-center bg-blue-700 pl-5 pr-5 text-white dark:text-white">Podman Command-Line</h2>
-        </div>
-      </div>
-      <div className="container mb-4 grid gap-2 lg:grid-cols-3">
-        <div className="mx-auto">
-          <img className="max-h-[200px]" src="images/optimized/podman-selkie-385w-358h.webp" />
-        </div>
-        <div className="col-span-2">
-          <p className="my-8 align-middle text-2xl leading-relaxed">
-            Podman's command-line interface allows you to find, run, build, and share containers.
+    <section className="bg-gradient-to-b from-gray-50 to-gray-100 py-16 dark:from-gray-700/25 dark:to-gray-900">
+      <div className="container flex flex-col items-center gap-8 text-center sm:flex-row sm:gap-12 sm:text-left">
+        <img
+          className="h-36 w-36 shrink-0 sm:h-44 sm:w-44"
+          src="/images/optimized/podman-selkie-385w-358h.webp"
+          alt="Podman CLI seal mascot"
+        />
+        <div>
+          <h2 className="mb-3 text-blue-700 dark:text-blue-500">Podman Command-Line</h2>
+          <p className="max-w-xl text-xl leading-relaxed text-gray-700 dark:text-gray-100">
+            Find, run, build, and share containers &mdash; all from a single, familiar CLI.
           </p>
         </div>
       </div>
@@ -170,23 +240,79 @@ const PodmanCLISection = () => {
   );
 };
 
+const learnMoreResources = [
+  {
+    icon: 'mdi:book-open-page-variant',
+    title: 'Documentation',
+    description: 'Guides and references to get you started.',
+    cta: 'Read the docs',
+    path: 'https://docs.podman.io',
+  },
+  {
+    icon: 'mdi:account-group',
+    title: 'Community',
+    description: 'Join us on Discord, IRC, or Matrix.',
+    cta: 'Get involved',
+    path: '/community',
+  },
+  {
+    icon: 'mdi:source-branch',
+    title: 'Contribute',
+    description: 'Help make Podman even better.',
+    cta: 'Contribute on GitHub',
+    path: 'https://github.com/containers/podman',
+  },
+  {
+    icon: 'mdi:rss',
+    title: 'Blog',
+    description: 'Release notes and updates from the team.',
+    cta: 'Read the blog',
+    path: 'https://blog.podman.io',
+  },
+];
+
 const LearnMoreSection = () => {
   return (
-    <section>
-      <SectionHeader title={learnMore.title} textGradient={true} textGradientStops="from-purple-500 to-purple-900" />
-      <div className="container mt-8 flex flex-wrap justify-center gap-24">
-        <BlogArticlesList
-          limit={2}
-          displayCount={2}
-          altLayout
-          title={learnMore.blogPosts.title}
-          titleColor="text-blue-700 dark:text-blue-500"
-          showFooter
-          footerText="Check out more posts about Podman"
-          containerLayout="vertical"
-          sectionClassName="my-4 lg:my-0"
-        />
-        <BasicResourcesBox />
+    <section className="py-4">
+      <div className="container">
+        <div className="flex flex-col items-center gap-6 rounded-2xl bg-gray-50 p-6 text-center dark:bg-gray-700/40 sm:flex-row sm:gap-8 sm:p-8">
+          <img
+            className="h-28 w-28 shrink-0 sm:h-32 sm:w-32"
+            src="/images/optimized/podman-2-196w-172h.webp"
+            alt="Podman seal"
+          />
+          <div className="flex-1">
+            <h2 className="mb-2 text-blue-700 dark:text-blue-500">{learnMore.title}</h2>
+            <p className="mb-4 text-gray-700 dark:text-gray-100">
+              Explore our documentation, join the community, and start contributing.
+            </p>
+            <a
+              href="https://docs.podman.io"
+              className="inline-flex items-center gap-1.5 rounded-md bg-purple-700 px-5 py-2.5 text-sm font-semibold text-white no-underline shadow-sm transition duration-150 ease-linear hover:bg-purple-900 hover:no-underline dark:bg-purple-700 dark:hover:bg-purple-500">
+              Explore documentation
+              <Icon icon="mdi:arrow-right" />
+            </a>
+          </div>
+        </div>
+
+        <h3 className="mb-6 mt-12 text-center text-blue-700 dark:text-blue-500">Resources</h3>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {learnMoreResources.map(item => (
+            <div key={item.title} className="rounded-xl border border-gray-100 p-5 dark:border-gray-700">
+              <span className="mb-3 flex h-10 w-10 items-center justify-center rounded-lg bg-purple-700 text-lg text-white">
+                <Icon icon={item.icon} />
+              </span>
+              <h4 className="mb-1 dark:text-white">{item.title}</h4>
+              <p className="mb-3 text-sm text-gray-500 dark:text-gray-300">{item.description}</p>
+              <a
+                href={item.path}
+                className="inline-flex items-center gap-1 text-sm font-semibold text-purple-700 no-underline hover:text-purple-900 dark:text-purple-300 dark:hover:text-purple-100">
+                {item.cta}
+                <Icon icon="mdi:arrow-right" />
+              </a>
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/src/pages/get-started.tsx
+++ b/src/pages/get-started.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import Layout from '@theme/Layout';
-import CodeBlock from '@theme/CodeBlock';
 /* COMPONENTS */
 import SectionHeader from '@site/src/components/layout/SectionHeader';
 import PageHeader from '@site/src/components/layout/PageHeader';
 import WaveBorder from '@site/src/components/shapes/WaveBorder';
-import CodeExampleSection from '@site/src/components/content/CodeExampleSection';
+import TerminalCard from '@site/src/components/utilities/TerminalCard';
 /* PAGE DATA */
 import { header, getHelp } from '@site/static/data/get-started';
 
@@ -15,37 +14,36 @@ const GetHelpSection = () => {
     <section className="bg-gradient-to-br from-purple-900 to-purple-500/75 dark:from-purple-700 dark:via-purple-900 dark:to-gray-900">
       <SectionHeader title={getHelp.title} textColor="dark:text-blue-500 text-blue-300" />
       <div className="container my-8">
-        <header className="text-center lg:my-8">
-          <h3 className="text-white dark:text-white ">{getHelp.subtitle}</h3>
+        <header className="text-center lg:mb-8">
+          <h3 className="text-white">{getHelp.subtitle}</h3>
         </header>
-        <div className="mx-auto">
-          <div className="container grid  grid-cols-1 gap-y-4 lg:grid-cols-2 lg:gap-y-0">
-            <p className="max-w-sm text-white dark:text-gray-100">
-              For more details, you can review the <a href="https://docs.podman.io/en/latest/Commands.html">manpages</a>
-              :
-            </p>
-            {/* prettier-ignore */}
-            <CodeBlock language="bash" showLineNumbers>
-                $ man podman {'\n'} 
-                $ man podman subcommand
-              </CodeBlock>
-          </div>
-          <div className="container grid grid-cols-1 gap-y-4 lg:grid-cols-2 lg:gap-y-0">
-            <p className="max-w-sm text-white">
+        <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 lg:grid-cols-2 lg:items-start">
+          <div className="rounded-2xl bg-white/10 p-6 backdrop-blur-sm lg:p-8">
+            <p className="mb-4 text-white">
               To get some help and find out how Podman is working, you can use the help.
             </p>
-            {/* prettier-ignore */}
-            <CodeBlock language="bash" showLineNumbers>
-                $ podman --help # get a list of all commands {'\n'}
-                $ podman subcommand --help # get info on a command
-              </CodeBlock>
+            <TerminalCard>{`$ podman --help # get a list of all commands
+$ podman subcommand --help # get info on a command`}</TerminalCard>
+          </div>
+          <div className="rounded-2xl bg-white/10 p-6 backdrop-blur-sm lg:p-8">
+            <p className="mb-4 text-white">
+              For more details, you can review the{' '}
+              <a href="https://docs.podman.io/en/latest/Commands.html" className="text-blue-300 hover:text-blue-100">
+                manpages
+              </a>
+              :
+            </p>
+            <TerminalCard>{`$ man podman
+$ man podman subcommand`}</TerminalCard>
           </div>
         </div>
       </div>
       <div className="container mb-8 mt-4 text-center lg:mb-20 lg:mt-6">
         <p className="text-white">
           Please also reference the{' '}
-          <a href="https://github.com/containers/podman/blob/main/troubleshooting.md" className="text-blue-300">
+          <a
+            href="https://github.com/containers/podman/blob/main/troubleshooting.md"
+            className="text-blue-300 hover:text-blue-100">
             <strong>Podman Troubleshooting Guide</strong>
           </a>{' '}
           to find known issues and tips on how to solve common configuration mistakes.
@@ -56,91 +54,124 @@ const GetHelpSection = () => {
   );
 };
 
-const SearchPullListSection = () => {
+const Note = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex items-start gap-3 rounded-xl bg-blue-50 p-4 dark:bg-blue-500/10">
+    <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md bg-blue-500 text-xs font-bold text-white">
+      i
+    </span>
+    <p className="text-sm text-gray-700 dark:text-gray-100">{children}</p>
+  </div>
+);
+
+const StepCard = ({ number, title, children }: { number: number; title: string; children: React.ReactNode }) => (
+  <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900 lg:p-8">
+    <h3 className="mb-4 text-purple-700 dark:text-purple-500">
+      {number}. {title}
+    </h3>
+    <div className="flex flex-col gap-6">{children}</div>
+  </div>
+);
+
+const GetStartedStepsSection = () => {
   return (
-    <section>
-      <SectionHeader textColor="text-purple-700 dark:text-purple-500" title="Searching, pulling, and listing images" />
-      <CodeExampleSection />
+    <section className="bg-gray-50 py-16 dark:bg-black">
+      <div className="container flex flex-col gap-8">
+        <StepCard number={1} title="Installing Podman">
+          <p className="text-gray-700 dark:text-gray-100">
+            For installing or building Podman, please see the{' '}
+            <a href="/docs/installation" className="text-blue-700 dark:text-blue-500">
+              installation instructions
+            </a>
+            .
+          </p>
+        </StepCard>
+
+        <StepCard number={2} title="Searching, pulling, and listing images">
+          <p className="text-gray-700 dark:text-gray-100">
+            Podman can search for images on remote registries with some simple keywords.
+          </p>
+          <TerminalCard>{`$ podman search httpd
+INDEX       NAME                                 DESCRIPTION                      STARS  OFFICIAL  AUTOMATED
+docker.io   docker.io/library/httpd              The Apache HTTP Server Project    3762             [OK]
+docker.io   docker.io/centos/httpd-24-centos7    Platform for running Apache...    40
+quay.io     quay.io/centos7/httpd-24-centos-7    Platform for running Apache...    0                [OK]
+docker.io   docker.io/centos/httpd                                                 34               [OK]
+redhat.com  registry.access.redhat.com/ubi8/httpd                                  0
+quay.io     quay.io/redhattraining/httpd-parent                                    0                [OK]
+
+$ podman pull docker.io/library/httpd
+Trying to pull docker.io/library/httpd:latest...
+Getting image source signatures
+Copying blob ab86dc02235d done
+Copying blob ba1caf8ba86c done
+Copying config d294bb32c2 done
+Writing manifest to image destination
+Storing signatures
+d294bb32c2073ecb5fb27e7802a1e5bec334af69cac361c27e6cb8546fdd14e7`}</TerminalCard>
+          <TerminalCard>{`$ podman images
+REPOSITORY               TAG      IMAGE ID       CREATED        SIZE
+docker.io/library/httpd  latest   d294bb32c207   12 hours ago   148 MB`}</TerminalCard>
+          <Note>
+            Podman searches in different registries. To make sure you're pulling the correct image, use the full image
+            name (<code>docker.io/library/httpd</code> instead of <code>httpd</code>).
+          </Note>
+        </StepCard>
+
+        <StepCard number={3} title="Running a container and listing running containers">
+          <p className="text-gray-700 dark:text-gray-100">
+            This sample container will run a very basic httpd server that serves only its index page.
+          </p>
+          <TerminalCard>{`$ podman run -dt -p 8080:80/tcp docker.io/library/httpd`}</TerminalCard>
+          <Note>
+            Because the container is being run in detached mode, represented by the <code>-d</code> in the{' '}
+            <code>podman run</code> command, Podman will run the container in the background and print the container ID
+            after it has executed the command. The <code>-t</code> also adds a pseudo-tty to run arbitrary commands in
+            an interactive shell. Also, we use port forwarding to be able to access the HTTP server. For successful
+            running at least <strong>slirp4netns</strong> v0.3.0 is needed.
+          </Note>
+          <p className="text-gray-700 dark:text-gray-100">
+            The <code>podman ps</code> command is used to list created and running containers.
+          </p>
+          <TerminalCard>{`$ podman ps
+CONTAINER ID  IMAGE                           COMMAND           CREATED       STATUS       PORTS                  NAMES
+01c44968199f  docker.io/library/httpd:latest  httpd-foreground  1 minute ago  Up 1 minute  0.0.0.0:8080->80/tcp  laughing_bob`}</TerminalCard>
+          <Note>
+            If you add <code>-a</code> to the <code>podman ps</code> command, Podman will show all containers (created,
+            exited, running, etc.).
+          </Note>
+        </StepCard>
+
+        <StepCard number={4} title="Reaching the container">
+          <p className="text-gray-700 dark:text-gray-100">
+            As you are able to see, the container does not have an IP Address assigned. The container is reachable via
+            its published port on your local machine.
+          </p>
+          <TerminalCard>{`$ curl http://localhost:8080`}</TerminalCard>
+          <p className="text-gray-700 dark:text-gray-100">
+            From another machine, you need to use the IP Address of the host, running the container.
+          </p>
+          <TerminalCard>{`$ curl http://<IP_Address>:8080`}</TerminalCard>
+          <Note>
+            Instead of using <code>curl</code>, you can also point a browser to <code>http://localhost:8080</code>.
+          </Note>
+        </StepCard>
+      </div>
     </section>
   );
 };
 
-const RunListContainersSection = () => {
-  return (
-    <section className="bg-gradient-to-br from-blue-500/75 to-blue-700 dark:bg-blue-900 dark:text-white pt-6 pb-16" >
-      <SectionHeader textColor="text-purple-700 dark:text-purple-500" title="Running a container &amp; listing running containers" />
-      <div className="text-center flex flex-col mx-4">
-        <p className="mb-4">This sample container will run a very basic httpd server that serves only its index page.</p>
-        
-        <h3 className="text-purple-700 dark:text-purple-300 mb-2 mt-10">Running a container</h3>
-
-        <div className="mx-auto">
-          <CodeBlock language="bash" showLineNumbers className="text-left overflow-scroll xl:max-w-6xl max-w-xs sm:max-w-md md:max-w-lg lg:max-w-4xl">
-            $ podman run -dt -p 8080:80/tcp docker.io/library/httpd {'\n'}
-          </CodeBlock>
-        </div>
-
-        <div className="mx-auto max-w-lg rounded-md bg-white/50 px-6 py-6 shadow-lg dark:bg-gray-900/50">
-          <h5 className="text-gray-700">Note:</h5>
-          <p className="text-gray-700 text-left">
-            Because the container is being run in detached mode, represented by the -d in the podman run command, 
-            Podman will run the container in the background and print the container ID after it has executed the 
-            command. The -t also adds a pseudo-tty to run arbitrary commands in an interactive shell.
-          </p>
-          <p className="text-gray-700 text-left mt-4">
-            Also, we use port forwarding to be able to access the HTTP server. For successful running at least <strong>slirp4netns</strong> v0.3.0 is needed.
-          </p>
-        </div>
-
-        <h3 className="text-purple-700 dark:text-purple-300 mt-16 mb-2">Listing running containers</h3>
-      
-        <div className="mx-auto">
-          <p className="text-gray-700 mb-4">The <code>podman ps</code> command is used to list created and running containers.</p>
-          <CodeBlock language="bash" showLineNumbers className="sm:bg-gray-100 text-left mx-4 overflow-scroll xl:max-w-6xl max-w-xs sm:max-w-md md:max-w-lg lg:max-w-4xl">
-            $ podman ps{'\n'}
-            CONTAINER ID  IMAGE                           COMMAND           CREATED       STATUS      PORTS                 NAMES{'\n'}
-            01c44968199f  docker.io/library/httpd:latest  httpd-foreground  1 minute ago  Up 1 minute 0.0.0.0:8080-{'>'}80/tcp  laughing_bob{'\n'}
-          </CodeBlock>
-          <div className="mx-auto max-w-lg rounded-md bg-white/50 px-6 py-6 shadow-lg dark:bg-gray-900/50">
-            <h5 className="text-gray-700">Note:</h5>
-            <p className="text-gray-700 text-left">
-             If you add <code>-a</code> to the <code>podman ps</code> command, Podman will show all containers (created, exited, running, etc.).
-            </p>
-          </div>
-        </div>
-     
-      <h3 className="text-purple-700 dark:text-purple-300 mt-16 mb-2">Testing the <code>httpd</code> container</h3>
-     
-      <div className="mx-auto">
-        <p className="text-gray-700 mb-4 text-left max-w-prose">As you are able to see, the container does not have an IP Address assigned. The container is reachable via its published port on your local machine.</p>
-        <CodeBlock language="bash" showLineNumbers className="sm:bg-gray-100 text-left mx-auto overflow-scroll xl:max-w-6xl max-w-xs sm:max-w-md md:max-w-lg lg:max-w-4xl">
-          $ curl http://localhost:8080{'\n'}
-        </CodeBlock>
-
-        <p className="text-gray-700 mb-4 max-w-prose text-left">From another machine, you need to use the IP Address of the host, running the container.</p>
-        <CodeBlock language="bash" showLineNumbers className="sm:bg-gray-100 text-left mx-auto overflow-scroll xl:max-w-6xl max-w-xs sm:max-w-md md:max-w-lg lg:max-w-4xl">
-          $ curl http://{'<IP_Address>'}:8080{'\n'}
-        </CodeBlock>
-
-        <div className="mx-auto max-w-lg rounded-md bg-white/50 px-6 py-6 shadow-lg dark:bg-gray-900/50">
-          <h5 className="text-gray-700">Note:</h5>
-          <p className="text-gray-700 text-left">
-          Instead of using <code>curl</code>, you can also point a browser to <code>http://localhost:8080</code>.</p>
-        </div>
-      </div>
-    </div>
-    </section>
-  )
-}
-
 /* PAGE CONTENT */
 function GetStarted() {
   return (
-    <Layout>
-      <PageHeader title={header.title} description={header.subtitle} basicResources={true} instructions={header.instructions} />
+    <Layout title="Get Started" description={header.subtitle}>
+      <PageHeader
+        title={header.title}
+        description={header.subtitle}
+        basicResources={true}
+        instructions={header.instructions}
+      />
       <GetHelpSection />
-      <SearchPullListSection />
-      <RunListContainersSection />
+      <GetStartedStepsSection />
     </Layout>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,13 +9,14 @@ import ThumbCard from '@site/src/components/ui/ThumbCard';
 import ColoringBookSection from '@site/src/components/content/ColoringBookSection';
 import TestimonialSection from '@site/src/components/content/TestimonialSection';
 import BlogArticlesList from '@site/src/components/content/BlogArticlesList';
+import Button from '@site/src/components/utilities/Button';
 /* PAGE DATA */
 import { header, featureList, kubernetesBanner, compatibleTools } from '@site/static/data/home';
 
 /* PAGE COMPONENTS */
 const FeatureItem = ({ title, description }) => {
   return (
-    <li className="m-6 rounded-md bg-gray-50 p-12 text-center dark:bg-gray-900 lg:w-1/3">
+    <li className="m-2 rounded-xl border border-gray-100 bg-gray-50 p-12 text-center shadow-sm transition duration-200 hover:-translate-y-1 hover:shadow-lg dark:border-gray-700 dark:bg-gray-900 lg:w-1/3">
       <h3 className="mx-auto mb-4 text-3xl font-bold text-purple-700 dark:text-purple-500">{title}</h3>
       <Markdown text={description} styles="mx-auto max-w-md leading-relaxed text-gray-700" />
     </li>
@@ -24,8 +25,8 @@ const FeatureItem = ({ title, description }) => {
 
 const FeatureSection = () => {
   return (
-    <section className="mb-12">
-      <ul className="flex flex-wrap justify-center gap-4">
+    <section className="container mx-auto mb-12">
+      <ul className="flex flex-wrap justify-center gap-6">
         {featureList.map(feature => {
           return <FeatureItem key={feature.title} title={feature.title} description={feature.description} />;
         })}
@@ -47,6 +48,24 @@ const CompatibleToolSection = () => {
   );
 };
 
+const BlogSection = () => {
+  return (
+    <section className="relative overflow-hidden bg-gray-50 py-16 dark:bg-gray-900/40 lg:py-20">
+      <div className="pointer-events-none absolute -top-16 right-1/4 h-64 w-64 rounded-full bg-purple-300/20 blur-3xl dark:bg-purple-700/10" />
+      <BlogArticlesList
+        limit={3}
+        title="Latest Podman News"
+        description="Release notes, deep dives, and updates from the Podman team and community."
+        titleColor="text-purple-700 dark:text-purple-500"
+        containerLayout="grid"
+      />
+      <div className="mt-10 flex justify-center">
+        <Button as="link" outline path="https://blog.podman.io" text="View all posts" />
+      </div>
+    </section>
+  );
+};
+
 /* PAGE CONTENT */
 function IndexPage() {
   return (
@@ -56,7 +75,7 @@ function IndexPage() {
       <InfoBanner {...kubernetesBanner} />
       <CompatibleToolSection />
       <TestimonialSection />
-      <BlogArticlesList limit={4} title="Latest Podman News" titleColor="text-purple-700" containerLayout="grid" />
+      <BlogSection />
       <ColoringBookSection />
     </Layout>
   );

--- a/src/plugins/meetingNotesPlugin.js
+++ b/src/plugins/meetingNotesPlugin.js
@@ -1,0 +1,32 @@
+const path = require('path');
+const { getMeetingNotes } = require('../lib/meetings');
+
+module.exports = function meetingNotesPlugin(context) {
+  return {
+    name: 'meeting-notes-plugin',
+
+    async loadContent() {
+      const notesDir = path.join(context.siteDir, 'static/data/meetings/notes');
+      return getMeetingNotes(notesDir);
+    },
+
+    async contentLoaded({ content, actions }) {
+      const { addRoute, createData, setGlobalData } = actions;
+
+      setGlobalData(content);
+
+      const allNotes = [...content.community, ...content.cabal];
+      await Promise.all(
+        allNotes.map(async note => {
+          const noteDataPath = await createData(`meeting-note-${note.slug}.json`, JSON.stringify(note));
+          addRoute({
+            path: `/community/meetings/${note.slug}`,
+            component: '@site/src/components/pages/MeetingNotePage/index.tsx',
+            modules: { note: noteDataPath },
+            exact: true,
+          });
+        }),
+      );
+    },
+  };
+};

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import { useThemeConfig } from '@docusaurus/theme-common';
+import { Icon } from '@iconify/react';
+
+type SocialLink = { label: string; path?: string; icon: string };
+
+const socialLinks: SocialLink[] = [
+  { label: 'X', path: 'https://twitter.com/Podman_io', icon: 'simple-icons:x' },
+  { label: 'Matrix', path: 'https://matrix.to/#/#podman:fedoraproject.org', icon: 'simple-icons:matrix' },
+  { label: 'IRC', path: 'https://web.libera.chat/#podman-desktop', icon: 'ph:chat-circle-text-fill' },
+  { label: 'YouTube', path: 'https://www.youtube.com/@Podman_io', icon: 'simple-icons:youtube' },
+  { label: 'LinkedIn', path: 'https://www.linkedin.com/company/podman', icon: 'simple-icons:linkedin' },
+];
+
+function Footer(): JSX.Element {
+  const { footer } = useThemeConfig();
+  const links = (footer?.links ?? []) as { title: string; items: { label: string; to?: string; href?: string }[] }[];
+
+  return (
+    <footer className="footer px-6 py-8">
+      <div className="mx-auto flex max-w-5xl flex-wrap justify-start gap-x-14 gap-y-8 lg:justify-between">
+        <div className="w-full text-left lg:w-auto">
+          <Link to="/" className="flex items-center gap-2">
+            <img
+              src="/logos/optimized/podman-3-logo-266w-253h.webp"
+              alt="Podman Logo"
+              className="h-10 w-10 object-contain"
+            />
+            <span className="font-display text-xl font-bold text-white">podman</span>
+          </Link>
+          <p className="mt-4 max-w-sm text-white/90">
+            Run secure, rootless containers with a lightweight, daemon-free container engine.
+          </p>
+          <ul className="mt-5 flex items-center justify-start gap-4">
+            {socialLinks.map(social => (
+              <li key={social.label}>
+                <a
+                  href={social.path}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={social.label}
+                  className="flex h-11 w-11 items-center justify-center rounded-full bg-white/10 text-2xl text-white no-underline grayscale transition duration-150 ease-linear hover:-translate-y-0.5 hover:bg-white/20 hover:no-underline">
+                  <Icon icon={social.icon} />
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {links.map(column => (
+          <div key={column.title}>
+            <div className="mb-4 font-display text-lg font-semibold text-white">{column.title}</div>
+            <ul className="flex flex-col gap-2">
+              {column.items.map(item => (
+                <li key={item.label}>
+                  {item.href ? (
+                    <a href={item.href} target="_blank" rel="noopener noreferrer">
+                      {item.label}
+                    </a>
+                  ) : (
+                    <Link to={item.to}>{item.label}</Link>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+      {footer?.copyright && (
+        <div
+          className="footer__copyright mx-auto mt-8 max-w-5xl text-center text-gray-300"
+          dangerouslySetInnerHTML={{ __html: footer.copyright }}
+        />
+      )}
+    </footer>
+  );
+}
+
+export default Footer;

--- a/static/data/community.ts
+++ b/static/data/community.ts
@@ -4,7 +4,7 @@ const header = {
   title: 'Community',
   subtitle:
     'We want your feedback, issues, patches, and involvement in the development of Podman. **Chat** with us on Matrix, Discord, IRC, or on our **mailing list**. Submit **issues & pull requests** (see our [CONTRIBUTING guide](https://github.com/containers/podman/blob/main/CONTRIBUTING.md) on how.) Participate in one of our twice-monthly community meetings. You are welcome in our community!',
-  image: 'images/optimized/podman-2-196w-172h.webp',
+  image: '/images/optimized/podman-2-196w-172h.webp',
   banner: {
     text: 'To help ensure all feel welcome in the Podman community, we expect all who participate to adhere to our [Code of Conduct](https://github.com/containers/common/blob/main/CODE-OF-CONDUCT.md)',
     icon: 'fa6-regular:handshake',
@@ -17,30 +17,43 @@ const communityChat = {
     'The Podman developers are generally around during CEST and Eastern Time business hours, so please be patient if you’re in another time zone!',
   links: [
     {
-      text: '#podman:matrix.org',
+      text: 'Matrix',
+      description: 'Chat with the community in real time on Matrix',
+      linkText: 'Join Matrix',
       path: 'https://matrix.to/#/#podman:fedoraproject.org',
       image: {
-        path: 'logos/optimized/element-56w-59h.webp',
+        path: '/logos/optimized/element-56w-59h.webp',
         alt: 'Element Matrix Logo',
       },
+      accentColor: 'text-blue-700 dark:text-blue-500',
     },
     {
-      text: '#podman on libera.chat',
+      text: 'IRC',
+      description: 'Join the conversation on our IRC channel',
+      linkText: 'Join IRC',
       path: 'https://web.libera.chat/#podman-desktop',
       textLogo: 'IRC',
+      accentColor: 'text-purple-700 dark:text-purple-500',
     },
     {
-      text: 'Podman GitHub Discussions',
+      text: 'GitHub',
+      description: 'Contribute, report issues, or browse the source code',
+      linkText: 'View Repository',
       path: 'https://github.com/containers/podman/discussions',
       image: {
-        path: 'vectors/raw/github.svg',
+        path: '/vectors/raw/github.svg',
         alt: 'GitHub Logo',
       },
+      invertInDark: true,
+      accentColor: 'text-gray-700 dark:text-gray-100',
     },
     {
-      text: 'Podman Discord',
+      text: 'Discord',
+      description: 'Join our Discord server for real-time support',
+      linkText: 'Join Discord',
       path: 'https://discord.gg/vwpj7K6gW5',
       icon: 'logos:discord-icon',
+      accentColor: 'text-deep-purple-700 dark:text-deep-purple-300',
     },
   ],
 };
@@ -50,7 +63,7 @@ const communityMeetings = {
   subtitle:
     "Many of the maintainers for the Podman project attend both of these meetings, so it's a great chance for community members like you to ask them questions or address concerns directly. If you have a topic that you’d like to propose for either meeting, please send a note to the [Mailing List]().",
   image: {
-    path: 'images/optimized/community-call-554w-219h.webp',
+    path: '/images/optimized/community-call-554w-219h.webp',
     alt: 'An image of podman team members in a virtual meeting',
   },
   cards: [
@@ -61,8 +74,8 @@ const communityMeetings = {
       date: '**1st Tuesday** of even numbered months',
       timeZone: '11 AM US ET /5 PM CET',
       buttons: [
-        { text: 'Join Meeting', path: MEETING_URL },
-        { text: 'Meeting Agenda', path: 'https://hackmd.io/fc1zraYdS0-klJ2KJcfC7w' },
+        { text: 'Join Meeting', path: MEETING_URL, icon: 'mdi:video-outline' },
+        { text: 'Meeting Agenda', path: 'https://hackmd.io/fc1zraYdS0-klJ2KJcfC7w', icon: 'mdi:text-box-outline' },
       ],
     },
     {
@@ -72,8 +85,12 @@ const communityMeetings = {
       date: '**1st Tuesday** of odd numbered months',
       timeZone: '11 AM US ET /5 PM CET',
       buttons: [
-        { text: 'Join Meeting', path: CABAL_MEETING_URL },
-        { text: 'Meeting Agenda', path: 'https://hackmd.io/gQCfskDuRLm7iOsWgH2yrg?both' },
+        { text: 'Join Meeting', path: CABAL_MEETING_URL, icon: 'mdi:video-outline' },
+        {
+          text: 'Meeting Agenda',
+          path: 'https://hackmd.io/gQCfskDuRLm7iOsWgH2yrg?both',
+          icon: 'mdi:text-box-outline',
+        },
       ],
     },
   ],
@@ -102,6 +119,7 @@ const mailingList = {
           text: 'Send email',
           path: 'mailto:podman-join@lists.podman.io',
         },
+        icon: 'mdi:email-fast-outline',
       },
       {
         title: 'Option 2',
@@ -111,12 +129,13 @@ const mailingList = {
           text: 'Sign up page',
           path: 'https://lists.podman.io/admin/lists/podman.lists.podman.io/',
         },
+        icon: 'mdi:cursor-default-click-outline',
       },
     ],
   },
   extraInfo: {
     image: {
-      path: 'images/optimized/mailing-list-screenshot-580w-376h.webp',
+      path: '/images/optimized/mailing-list-screenshot-580w-376h.webp',
       alt: 'A screenshot of the Podman mailing list home screen.',
     },
     note: {

--- a/static/data/features.ts
+++ b/static/data/features.ts
@@ -3,7 +3,7 @@ const header = {
   subtitle:
     'Podman is an open source container, pod, and container image management engine. Podman makes it easy to find, run, build, and share containers.',
   image: {
-    path: 'images/optimized/podman-2-196w-172h.webp',
+    path: '/images/optimized/podman-2-196w-172h.webp',
     alt: 'Podman Seal Image',
   },
 };
@@ -16,7 +16,7 @@ const knowPodman = {
       description:
         "Hop on over to our [Docs](/docs) and we'll lead you through the basic Podman commands Guide and give you pointers to more learning materials and guides.",
       image: {
-        path: 'images/optimized/characters/seal-diving-276w-226h.webp',
+        path: '/images/optimized/characters/seal-diving-276w-226h.webp',
         alt: 'A seal diving into the water',
       },
     },
@@ -25,7 +25,7 @@ const knowPodman = {
       description:
         'Podman has an active chat and mailing list, and regular open community meetings. Users and aspiring contributors are most welcome in all of these venues. Join us!',
       image: {
-        path: 'images/optimized/characters/seals-swimming-205w-238h.webp',
+        path: '/images/optimized/characters/seals-swimming-205w-238h.webp',
         alt: 'A group of seals swimming.',
       },
     },
@@ -34,7 +34,7 @@ const knowPodman = {
       description:
         'Check out the [Podman Troubleshooting Guide](https://github.com/containers/podman/blob/main/troubleshooting.md), search our [Documentation](https://docs.podman.io), or file an issue in our [issue tracker](https://github.com/containers/podman/issues).',
       image: {
-        path: 'images/optimized/characters/confused-seal-231w-248h.webp',
+        path: '/images/optimized/characters/confused-seal-231w-248h.webp',
         alt: 'A confused seal.',
       },
     },
@@ -49,7 +49,7 @@ const carouselContent = [
     description:
       'Find and pull down containers whether they are on dockerhub.io or quay.io, an internal registry server, or direct from a vendor.',
     image: {
-      path: 'images/optimized/cli-screens/cli-find-image.webp',
+      path: '/images/optimized/cli-screens/cli-find-image.webp',
       alt: 'A screenshot of the commandline while using the search and pull commands',
     },
   },
@@ -60,7 +60,7 @@ const carouselContent = [
     description:
       'Find and pull down containers whether they are on dockerhub.io or quay.io, an internal registry server, or direct from a vendor.',
     image: {
-      path: 'images/optimized/cli-screens/cli-run-image.webp',
+      path: '/images/optimized/cli-screens/cli-run-image.webp',
       alt: 'A screenshot of the commandline while using the run command',
     },
   },
@@ -70,7 +70,7 @@ const carouselContent = [
     subtitle: 'Podman Troubleshooting Guide',
     description: 'Creating new layers with small tweaks or major overhauls is easy with podman build',
     image: {
-      path: 'images/optimized/cli-screens/cli-build-image.webp',
+      path: '/images/optimized/cli-screens/cli-build-image.webp',
       alt: 'A screenshot of the commandline while using the build command',
     },
   },
@@ -81,7 +81,7 @@ const carouselContent = [
     description:
       'Podman lets you push your newly-built containers anywhere you want with a single podman push command.',
     image: {
-      path: 'images/optimized/cli-screens/cli-share-image.webp',
+      path: '/images/optimized/cli-screens/cli-share-image.webp',
       alt: 'A screenshot of the commandline while using the push command',
     },
   },

--- a/static/data/get-started.ts
+++ b/static/data/get-started.ts
@@ -7,7 +7,7 @@ const header = {
     subtitle: 'For installing or building Podman, please see the installation instructions:',
     button: {
       text: 'Installation Instructions',
-      path: 'docs/installation',
+      path: '/docs/installation',
       icon: 'fa6-solid:book',
     },
   },

--- a/static/data/global.ts
+++ b/static/data/global.ts
@@ -1,6 +1,8 @@
 export const LATEST_VERSION = '6.1.0';
 export const LATEST_DESKTOP_VERSION = '1.29.1';
 export const LATEST_DESKTOP_DOWNLOAD_URL = 'https://podman-desktop.io/blog/podman-desktop-release-1.29';
-export const MEETING_URL = 'https://zoom-lfx.platform.linuxfoundation.org/meeting/97486138230?password=3144ae43-0fd5-457e-a495-bb4e0202e9c2';
-export const CABAL_MEETING_URL = 'https://zoom-lfx.platform.linuxfoundation.org/meeting/96844452039?password=cc6cf3da-6a3b-437b-88d4-d1c233ffd352';
+export const MEETING_URL =
+  'https://zoom-lfx.platform.linuxfoundation.org/meeting/97486138230?password=3144ae43-0fd5-457e-a495-bb4e0202e9c2';
+export const CABAL_MEETING_URL =
+  'https://zoom-lfx.platform.linuxfoundation.org/meeting/96844452039?password=cc6cf3da-6a3b-437b-88d4-d1c233ffd352';
 export const RELEASE_NOTES = '';

--- a/static/data/home.ts
+++ b/static/data/home.ts
@@ -5,7 +5,7 @@ const header = {
   subtitle:
     'Manage containers, pods, and images with Podman. Seamlessly work with containers and Kubernetes from your local environment.',
   image: {
-    path: 'images/optimized/podman-ui-1200w-646h.webp',
+    path: '/images/optimized/podman-ui-1200w-646h.webp',
     alt: 'Two screenshots of the Podman Desktop user interface',
   },
   podmanrelease: {
@@ -16,12 +16,12 @@ const header = {
     text: LATEST_DESKTOP_VERSION,
     path: LATEST_DESKTOP_DOWNLOAD_URL,
   },
+  platformsLabel: 'Supported Platforms',
   platforms: [
-    'Supported Platforms',
-    'fa6-brands:redhat',
-    'fa6-brands:apple',
-    'fa6-brands:microsoft',
-    'fa6-brands:linux',
+    { icon: 'fa6-brands:redhat', label: 'RHEL', path: '/docs/installation#rhel' },
+    { icon: 'fa6-brands:apple', label: 'macOS', path: '/docs/installation#macos' },
+    { icon: 'fa6-brands:microsoft', label: 'Windows', path: '/docs/installation#windows' },
+    { icon: 'fa6-brands:linux', label: 'Linux', path: '/docs/installation#installing-on-linux' },
   ],
 };
 
@@ -57,7 +57,7 @@ const kubernetesBanner = {
   description:
     'Create, start, inspect, and manage pods. Play Kubernetes YAML directly with Podman, generate Kubernetes YAML from pods, and deploy to existing Kubernetes environments.',
   image: {
-    src: 'logos/optimized/kubernetes-logo-147w-143h.webp',
+    src: '/logos/optimized/kubernetes-logo-147w-143h.webp',
     alt: 'Kubernetes Logo',
   },
 };
@@ -68,22 +68,22 @@ const compatibleTools = {
     {
       title: 'VS Code',
       description: 'Visual Studio Code includes Podman support',
-      image: { path: 'logos/optimized/vscode-logo-75w-75h.webp', alt: 'VS Code Logo' },
+      image: { path: '/logos/optimized/vscode-logo-75w-75h.webp', alt: 'VS Code Logo' },
     },
     {
       title: 'Cirrus',
       description: 'Cirrus CLI allows you to reproducibly run containerized tasks with Podman',
-      image: { path: 'logos/optimized/cirrus-logo-75w-75h.webp', alt: 'Cirrus Logo' },
+      image: { path: '/logos/optimized/cirrus-logo-75w-75h.webp', alt: 'Cirrus Logo' },
     },
     {
       title: 'GitHub Actions',
       description: 'GitHub Actions include support for Podman, as well as friends buildah and skopeo',
-      image: { path: 'logos/optimized/github-logo-115w-115h.webp', alt: 'GitHub Logo' },
+      image: { path: '/logos/optimized/github-logo-115w-115h.webp', alt: 'GitHub Logo' },
     },
     {
       title: 'Kind',
       description: "Kind's ability to run local Kubernetes clusters via container nodes includes support for Podman",
-      image: { path: 'logos/optimized/kind-logo-165w-95h.webp', alt: 'Kind Logo' },
+      image: { path: '/logos/optimized/kind-logo-165w-95h.webp', alt: 'Kind Logo' },
     },
   ],
 };

--- a/static/data/meetings/notes/2026-08-04/index.md
+++ b/static/data/meetings/notes/2026-08-04/index.md
@@ -1,27 +1,33 @@
 # Podman Community Meeting Notes
+
 ## Aug 4, 2026 11:00 a.m. Eastern (UTC-4)
 
 ### Attendees
+
 Tom Sweeney, Pranav Jogdand, Nalin Dahyabhai, Kartik Yadav, Pratik Patil, Miloslav Trmac, Ashley Cui, Giuseppe Scrivano, Joshua Arrevillaga, Paul Holzinger,Marek Simek, Kevin Clevenger, Jetshree Sharma, Lokesh Mandvekar, Tim Zhou, Brent Baude, Gagan U
 
 ### Meeting Notes
+
 Video [Recording](https://youtu.be/W3cWHSrQnEQ)
 
 Meeting start: 11:02 a.m. EDT (UTC-4)
 
 #### Quick Recap
+
 The Podman Community Meeting covered updates and demos related to recent Podman releases and LFX internships. Paul demonstrated improvements in port forwarding for custom networks in Podman 6.1 RC1, showing how source IP addresses are now correctly preserved. The group discussed the upcoming final release of Podman 6.1, noting it mostly included bug fixes and a few new features. Tom and Ashley provided information about the LFX internships, emphasizing that prior contributions were not required for applicants and addressing questions about the application process, design portfolios, and cover letters. Several participants, including Kartik and Pratik, asked for clarification on internship expectations and project proposals. The conversation ended with a reminder for topic submissions for the next meeting and thanks to the presenters and attendees.
 
 #### Next Steps
-  * Tom: Review the number of applications received for the LFX internships.
-  * Kartik: Check the CNCF/monitoring repo issue for the broken text on the LFX portal and consider creating an issue or PR if not already done.
-  * All interested applicants: Apply for the LFX internships before the closing date of August 18th.
-  * All interested applicants: Prepare a design portfolio for the website UX project, including descriptions of contributions, and a cover letter outlining relevant experience and project approach.
-  * All interested applicants for the automation project: Consider including some code samples or contributions (personal, school, or open-source) in the application, though it is not strictly required.
-  * All attendees: Submit topics for the next Podman Community Meeting (October 6, 2026).
+
+- Tom: Review the number of applications received for the LFX internships.
+- Kartik: Check the CNCF/monitoring repo issue for the broken text on the LFX portal and consider creating an issue or PR if not already done.
+- All interested applicants: Apply for the LFX internships before the closing date of August 18th.
+- All interested applicants: Prepare a design portfolio for the website UX project, including descriptions of contributions, and a cover letter outlining relevant experience and project approach.
+- All interested applicants for the automation project: Consider including some code samples or contributions (personal, school, or open-source) in the application, though it is not strictly required.
+- All attendees: Submit topics for the next Podman Community Meeting (October 6, 2026).
 
 ### Topics
-#### Pasta Forwarding Demo - Paul Holzinger  ([01:29](https://www.youtube.com/watch?v=W3cWHSrQnEQ&t=89s) in the video)
+
+#### Pasta Forwarding Demo - Paul Holzinger ([01:29](https://www.youtube.com/watch?v=W3cWHSrQnEQ&t=89s) in the video)
 
 Paul demonstrated new port forwarding functionality in Podman 6 and 6.1 that addresses a long-standing issue with incorrect source IP addresses in custom networks. The demonstration showed how the previous standard poster mode worked with default networks but failed with custom networks, causing remote connections to appear with incorrect IP addresses in web server logs. Paul explained that they added a new port forwarding mode in Podman 6.0 and made further improvements in 6.1, including support for IPv6 connections in dual-stack networks.
 
@@ -29,34 +35,38 @@ Paul demonstrated new features in Podman 6.1 RC1, which was released on Friday. 
 
 #### Podman 6.1 RC1 update - Paul Holzinger, Tom Sweeney - ([08:47](https://www.youtube.com/watch?v=W3cWHSrQnEQ&t=527s) in the video)
 
-Tom and Paul discussed the recent release, which focused mainly on bug fixes and included new features like Podman volume rename and Podman machine restart. It was released on Friday July 29, 2026.  They confirmed plans for the final release next week and the next major release, 6.2, in November. Tom also announced updates to the container tools, including new versions of Buildah (1.45) and Skopeo (1.24),
+Tom and Paul discussed the recent release, which focused mainly on bug fixes and included new features like Podman volume rename and Podman machine restart. It was released on Friday July 29, 2026. They confirmed plans for the final release next week and the next major release, 6.2, in November. Tom also announced updates to the container tools, including new versions of Buildah (1.45) and Skopeo (1.24),
 
 #### LFX Internships for Podman - Ashley Cui, Paul Holzinger, Tom Sweeney - ([12:39](https://www.youtube.com/watch?v=W3cWHSrQnEQ&t=759s) in the video)
 
 Two interns for September through November of 2026, applications close in a few weeks on August 18.
 
- * Podman.io https://mentorship.lfx.linuxfoundation.org/project/42be74e1-704b-4b17-8b47-e38f37338414
- * CI FLakes https://mentorship.lfx.linuxfoundation.org/project/050e89d9-aec2-47ad-9113-3ba41a639d55
- 
+- Podman.io https://mentorship.lfx.linuxfoundation.org/project/42be74e1-704b-4b17-8b47-e38f37338414
+- CI FLakes https://mentorship.lfx.linuxfoundation.org/project/050e89d9-aec2-47ad-9113-3ba41a639d55
+
 ##### Application Deadlines and Requirements:
+
 The team discussed application deadlines, with Kartik confirming the applications close on August 18th. Paul mentioned receiving many applications to review, noting that only one candidate can be selected. Kartik raised questions about the website UX project, including broken text on the LFX portal and requirements for the design portfolio and cover letter. Ashley clarified that the design portfolio should showcase separate work rather than the website itself, and should include descriptions of what was designed and contributed.
 
 ##### Project Expectations and Contributions Discussion:
-The team discussed expectations for an upcoming project, with Tom suggesting that mentees should provide quick examples of their previous work, including school projects, work-related tasks, and personal projects, highlighting what they specifically contributed. Paul clarified that while pre-contribution to Podman is not required, having some previous contribution, such as open-source work or a GitHub presence, would be beneficial. 
+
+The team discussed expectations for an upcoming project, with Tom suggesting that mentees should provide quick examples of their previous work, including school projects, work-related tasks, and personal projects, highlighting what they specifically contributed. Paul clarified that while pre-contribution to Podman is not required, having some previous contribution, such as open-source work or a GitHub presence, would be beneficial.
 
 ##### Internship Application Discussion:
+
 Kartik asked if he should include his implemented features in his cover letter, such as fixing RSS feeds and auto-detecting OS systems, and Tom advised that anything pertinent to the internship would be appropriate to include. Miloslav added that while they don't want the internship to begin before selecting a candidate, demonstrating competence is welcome. The conversation ended with Tom thanking participants and announcing the next meeting on October 6th.
 
 The next meeting is scheduled for October 6th, with hopes to have more demonstrations ready, particularly given that version 6.1 will be finalized by then.
 
 #### Open discussion
- 1. No further topics discussed 
+
+1.  No further topics discussed
 
 ### Next Community Meeting: Tuesday, October 6, 2026, 11:00 a.m. EST (UTC-4)
 
 #### Possible Topics:
- 1. None Discussed
 
+1.  None Discussed
 
 Meeting finished 11:26 a.m.
 
@@ -70,7 +80,7 @@ The first 10 minutes and 51 seconds of the meeting's recording were cut, so the 
 00:22:34	Tom Sweeney (Red Hat LLC):	https://github.com/podman-container-tools/podman/releases
 00:22:57	Tom Sweeney (Red Hat LLC):	Release Announcement.^^
 00:23:44	Tom Sweeney (Red Hat LLC):	* Podman.io https://mentorship.lfx.linuxfoundation.org/project/42be74e1-704b-4b17-8b47-e38f37338414
- * CI FLakes https://mentorship.lfx.linuxfoundation.org/project/050e89d9-aec2-47ad-9113-3ba41a639d55 
+ * CI FLakes https://mentorship.lfx.linuxfoundation.org/project/050e89d9-aec2-47ad-9113-3ba41a639d55
 ```
 
 ### Raw Zoom Meet Transcript

--- a/yarn.lock
+++ b/yarn.lock
@@ -9695,12 +9695,13 @@ __metadata:
     clsx: ^1.2.1
     eslint: ^8.32.0
     eslint-config-prettier: ^8.6.0
+    gray-matter: ^4.0.3
     html-react-parser: ^3.0.16
     husky: ^8.0.3
     lint-staged: ^13.1.0
     papaparse: ^5.4.1
     postcss: ^8.5.23
-    prettier: 2.8.8
+    prettier: ^3.9.6
     prettier-plugin-tailwindcss: ^0.8.1
     prism-react-renderer: ^1.3.5
     react: ^17.0.2
@@ -10297,12 +10298,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:2.8.8":
-  version: 2.8.8
-  resolution: "prettier@npm:2.8.8"
+"prettier@npm:^3.9.6":
+  version: 3.9.6
+  resolution: "prettier@npm:3.9.6"
   bin:
-    prettier: bin-prettier.js
-  checksum: b49e409431bf129dd89238d64299ba80717b57ff5a6d1c1a8b1a28b590d998a34e083fa13573bc732bb8d2305becb4c9a4407f8486c81fa7d55100eb08263cf8
+    prettier: bin/prettier.cjs
+  checksum: 3fb6a3b6462b05afb825697a3fdcdd9bd1480c11d10d655b7ddbcaf2560beb695caffbe155b5020466005aa06bff74a61ba9c16e602bff849331b62f5db26cdf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
DRAFT NOTE (delete this comment before marking ready for review):
Everything below "Concisely describe the change" is a factual, file-by-file
list for YOU to rewrite in your own words. Per this repo's LLM Policy and
the PR template checklist, the submitted description must be human-written.
Do not paste this section verbatim — summarize it in your own understanding.
-->

#### Concisely describe the change

TODO: rewrite the section below in your own words before marking ready for review.

This addresses part of the "Website Design and UX Improvements" scope from the
LFX mentorship issue (containers/podman.io#512): the Downloads page with OS
auto-detection, meeting minutes getting their own shareable pages, and a pass
through the "broken links, formatting problems, stale content" backlog
mentioned in that issue.

**Downloads page + OS auto-detection**
- `src/pages/downloads.tsx`, `src/components/content/DownloadsGrid/`: new
  `/downloads` page. Each OS (Windows/macOS/Linux) gets its own section;
  `src/lib/detectOperatingSystem.ts` reads `navigator.userAgent` client-side
  and the matching section is reordered to the top and visually highlighted
  ("Recommended for your system" badge). Previously "Other Install Options"
  on the homepage just linked to the install docs — there was no dedicated
  download page at all.

**Meeting minutes pages**
- `src/plugins/meetingNotesPlugin.js`, `src/components/pages/MeetingNotePage/`:
  a custom Docusaurus plugin reads `static/data/meetings/notes/*/index.md`
  and generates a static route per meeting, each with its own shareable URL.
  Replaces the old approach of wildcard-importing every note file into a
  manually maintained index and rendering them inside a modal popup — that
  approach also silently dropped the most recent meeting whenever the export
  list wasn't updated, and notes couldn't be linked to directly.

**Site-wide footer link bug (404 on almost every page)**
- `docusaurus.config.js`: the custom footer's `to:` values for
  Downloads/Installation/Documentation were relative paths without a leading
  `/` (`to: 'downloads'` instead of `to: '/downloads'`). Docusaurus's `<Link>`
  only auto-prefixes the site base URL for paths starting with `/`; without
  it, the path resolves relative to whatever page you're currently on. So
  from any blog post, docs page, or community page — i.e. everywhere except
  the homepage — clicking those footer links 404'd (e.g.
  `/blogs/2018/08/15/downloads` instead of `/downloads`). Confirmed via a
  full crawl of all ~600 built pages before and after the fix (0 broken
  internal links after).

**Dead links in old blog posts (18 links across 9 files)**
- Several 2019–2022 blog posts linked to retired URL patterns on our own
  domain that no longer resolve: `podman.io/releases/*.html` (now
  `/release/*`), `podman.io/community/#*` and `podman.io/getting-started/*`
  (now `/community` and `/get-started`). Repointed each to the current
  working route; left untouched anything pointing to genuinely dead
  third-party content (deleted Twitter accounts, discontinued BlueJeans
  links, etc. — nothing on our end can fix a 404 on someone else's site).

**Component bugs fixed along the way**
- `InfoBanner`: default gradient was missing `bg-gradient-to-r`, so the
  from/via/to color classes never actually rendered as a gradient; a
  caller-supplied background was also always masked by the default. Both
  banners on the Community page were meant to be purple but rendered blue.
- Blog card author link: the WordPress REST API query was missing `author`
  from `_fields`, so the author link always pointed at the generic
  `/author/` page instead of the post's actual author.
- `CustomCard`: picked link-vs-modal for its secondary button by array
  index instead of checking whether the button actually has a path, and
  wrapped react-markdown's own block output in an extra `<p>` (invalid
  HTML nesting).
- `FeaturesCarousel`: stray `'0 '` class typo.
- `CommunityMeetingsCardGrid`: used `justify-content-center` /
  `align-items-center` (not real Tailwind classes, no-ops) and had
  unguarded `.shift()` calls that could push `undefined` into child
  components on short meeting lists.

**Redesign work carried in this branch**
- Navbar, footer, Get Started page, and docs sidebar/TOC styling ported
  to match the site's Next.js reference design (numbered step cards,
  terminal-style code blocks with copy buttons, pill-highlighted active
  nav/sidebar items, gradient navbar, swizzled Footer with logo/social
  icons).

#### Before screenshot / screen recording

Link : https://drive.google.com/file/d/1zM6Xuh6wZZ4e2u30hin61HK6eCpC4RNU/view?usp=sharing

#### After screenshot / screen recording

Link : https://drive.google.com/file/d/1ot4A2KdjLYu93Q4dWY9OgkKY9bavGajo/view?usp=sharing

#### Checklist

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`).
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
