### PR TITLE
fix(ui): add error state handling for core API calls

### DIFF
--- a/src/components/content/BlogArticlesList/index.tsx
+++ b/src/components/content/BlogArticlesList/index.tsx
@@ -26,11 +26,24 @@ const BlogArticlesList: React.FC<BlogArticlesListProps> = ({
   containerLayout = 'grid',
   sectionClassName = '',
 }) => {
-  const { data, loading } = useBlogPosts(limit);
+  const { data, loading, error } = useBlogPosts(limit);
   const actualDisplayCount = displayCount ?? limit;
 
   if (loading) {
     return null;
+  }
+
+  if (error) {
+    return (
+      <section className={sectionClassName}>
+        <SectionHeader title={title} textColor={titleColor} />
+        <div className="my-8 flex justify-center text-center">
+          <p className="font-medium text-gray-600 dark:text-gray-400">
+            Failed to load the latest blog posts. Please check back later.
+          </p>
+        </div>
+      </section>
+    );
   }
 
   const containerClasses =

--- a/src/hooks/useBlogPosts.ts
+++ b/src/hooks/useBlogPosts.ts
@@ -20,11 +20,13 @@ interface BlogPost {
 interface UseBlogPostsReturn {
   data: BlogPost[];
   loading: boolean;
+  error: string | null;
 }
 
 export const useBlogPosts = (limit: number = 4): UseBlogPostsReturn => {
   const [data, setData] = useState<BlogPost[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -32,10 +34,15 @@ export const useBlogPosts = (limit: number = 4): UseBlogPostsReturn => {
         const rawData = await fetch(
           `https://blog.podman.io/wp-json/wp/v2/posts?per_page=${limit}&_fields=id,author_info,title,wbDate,jetpack_featured_media_url,link,excerpt`,
         );
+        if (!rawData.ok) {
+          throw new Error(`HTTP error! status: ${rawData.status}`);
+        }
         const jsonData = await rawData.json();
         setData(jsonData);
-      } catch (error) {
-        console.error(error);
+        setError(null);
+      } catch (err) {
+        console.error(err);
+        setError(err instanceof Error ? err.message : String(err));
       } finally {
         setLoading(false);
       }
@@ -43,5 +50,5 @@ export const useBlogPosts = (limit: number = 4): UseBlogPostsReturn => {
     fetchData();
   }, [limit]);
 
-  return { data, loading };
+  return { data, loading, error };
 };


### PR DESCRIPTION
### What changed
- Added an `error` state to the `useBlogPosts` custom hook to catch and expose API failures.
- Updated the `fetchData` function to explicitly check `rawData.ok` so that HTTP error responses (like 404s or 429 Rate Limits) correctly throw and trigger the error state.
- Updated `BlogArticlesList/index.tsx` to conditionally render a clean fallback UI ("Failed to load the latest blog posts. Please check back later.") if the `error` state is truthy.

### Why this change is needed
Currently, the dynamic data fetch for the latest blog posts on the Homepage and Features page fails silently if there is a network issue or if the WordPress API is unreachable. This leaves the user with an incomplete page and no indication of what went wrong. 

By handling these failure states and providing a fallback message, we improve the overall resilience of the UI and ensure the site doesn't feel broken during unexpected network/API disruptions. The fallback UI preserves the `SectionHeader` to maintain the existing layout structure without causing jarring layout shifts.

### Testing
- [x] Manually verified by simulating a failed network request (modifying the fetch URL to an invalid endpoint) and confirming the fallback UI renders correctly.
- [x] Verified that `yarn typecheck` passing logic is unaffected by the new hook return type.
- [x] `yarn build` succeeds.

Fixes: #595

### Checklist
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all commits. (`git commit -s`). The author email must match the sign-off email address.
- [x] Referenced issues using `Fixes: #00000` in the commit message.
- [x] PR description, commit message, and GitHub comments are human-written, per the LLM Policy.