### PR TITLE
Feat/issue 707 downloads page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,6 +79,7 @@ const config = {
         items: [
           { to: 'features', label: 'Features', position: 'right' },
           { to: 'get-started', label: 'Get Started', position: 'right' },
+          { to: 'downloads', label: 'Downloads', position: 'right' },
           { to: 'community', label: 'Community', position: 'right' },
           {
             to: 'https://blog.podman.io',

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -146,7 +146,17 @@
   h3,
   h4,
   h5 {
-    @apply font-display dark:text-gray-300;
+    @apply font-display;
+    color: var(--ifm-heading-color);
+  }
+  
+  html[data-theme='dark'] h1,
+  html[data-theme='dark'] h2,
+  html[data-theme='dark'] h2>a,
+  html[data-theme='dark'] h3,
+  html[data-theme='dark'] h4,
+  html[data-theme='dark'] h5 {
+    @apply text-gray-300;
   }
 
   /* main text */
@@ -157,13 +167,30 @@
   ol,
   figcaption,
   blockquote {
-    @apply font-text text-lg dark:text-gray-100 lg:text-xl;
+    @apply font-text text-lg lg:text-xl;
+    color: var(--ifm-font-color-base);
+  }
+
+  html[data-theme='dark'] p,
+  html[data-theme='dark'] dl,
+  html[data-theme='dark'] dt,
+  html[data-theme='dark'] dd,
+  html[data-theme='dark'] ol,
+  html[data-theme='dark'] figcaption,
+  html[data-theme='dark'] blockquote {
+    @apply text-gray-100;
   }
 
   /* monospace */
   code,
   pre {
-    @apply font-mono text-lg dark:text-gray-100 lg:text-xl;
+    @apply font-mono text-lg lg:text-xl;
+    color: var(--ifm-font-color-base);
+  }
+
+  html[data-theme='dark'] code,
+  html[data-theme='dark'] pre {
+    @apply text-gray-100;
   }
 
   a {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -39,19 +39,40 @@
   padding: 8px 0px;
   letter-spacing: -1.5px !important;
   font-kerning: normal !important;
+  transition: color 0.4s ease;
 }
 
 #__docusaurus > nav > div.navbar__inner > div:nth-child(1) > a > b {
   font-size: xxx-large;
   line-height: 2rem;
 }
-
 .navbar__logo {
   height: 6.25rem;
+  width: 6.57rem;
+  min-width: 6.57rem;
+  min-height: 6.25rem;
+  flex: 0 0 auto;
+  transition: opacity 0.4s ease;
+}
+
+.navbar__logo img {
+  height: 100%;
+  width: 100%;
+  aspect-ratio: 266 / 253;
+  object-fit: contain;
+  display: block;
+  transition: opacity 0.4s ease, filter 0.4s ease;
+  will-change: opacity;
+}
+
+.navbar__brand {
+  min-height: 6.25rem;
+  align-items: center;
 }
 
 .navbar {
   box-shadow: none;
+  transition: background 0.4s ease, background-color 0.4s ease;
   @apply bg-gradient-to-r from-blue-500  to-purple-700 dark:from-blue-700 dark:to-purple-900;
 }
 
@@ -79,7 +100,8 @@
 
 .navbar__link,
 .navbar__brand {
-  @apply no-underline transition duration-150 ease-linear hover:text-purple-300;
+  @apply no-underline hover:text-purple-300;
+  transition: color 0.4s ease, opacity 0.4s ease;
 }
 
 .footer {

--- a/src/pages/downloads.tsx
+++ b/src/pages/downloads.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useState } from 'react';
+import Layout from '@theme/Layout';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import { Icon } from '@iconify/react';
+
+import { downloadOptions, headerData, DownloadOption } from '@site/static/data/downloads';
+
+function DownloadCard({ option, isRecommended }: { option: DownloadOption; isRecommended?: boolean }) {
+  return (
+    <div className={`flex w-full max-w-sm flex-col rounded-xl p-8 text-center shadow-lg transition-transform hover:-translate-y-1 ${isRecommended ? 'border-2 border-purple-700 bg-purple-50 dark:bg-purple-900/20' : 'bg-white dark:bg-gray-800'}`}>
+      {isRecommended && (
+        <span className="mb-4 inline-block rounded-full bg-purple-100 px-3 py-1 text-xs font-semibold text-purple-800 dark:bg-purple-900 dark:text-purple-300">
+          Recommended for your OS
+        </span>
+      )}
+      <Icon icon={option.icon} className="mx-auto mb-4 text-6xl text-gray-700 dark:text-gray-300" />
+      <h3 className="mb-2 text-2xl font-bold">{option.title}</h3>
+      <p className="mb-6">{option.description}</p>
+      
+      <div className="mt-auto flex flex-col gap-4">
+        <div className="flex flex-col gap-2">
+          <a
+            href={option.desktop.url}
+            className="rounded-lg bg-purple-700 px-6 py-3 font-semibold !text-white transition-colors hover:bg-purple-900 hover:no-underline"
+          >
+            {option.desktop.label}
+          </a>
+          {option.desktop.instructionsUrl && (
+            <a href={option.desktop.instructionsUrl} className="text-sm !text-purple-700 hover:underline dark:!text-purple-300">
+              Desktop Install Instructions
+            </a>
+          )}
+        </div>
+        
+        <div className="my-2 border-t border-gray-200 dark:border-gray-700"></div>
+        
+        <div className="flex flex-col gap-2">
+          <a
+            href={option.cli.url}
+            className="rounded-lg border-2 border-purple-700 px-6 py-3 font-semibold !text-purple-700 transition-colors hover:bg-purple-50 hover:no-underline dark:border-purple-300 dark:!text-purple-300 dark:hover:bg-purple-900/30"
+          >
+            {option.cli.label}
+          </a>
+          {option.cli.instructionsUrl && (
+            <a href={option.cli.instructionsUrl} className="text-sm !text-purple-700 hover:underline dark:!text-purple-300">
+              CLI Install Instructions
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Detects the user's OS using modern APIs with fallbacks */
+function detectOS(): 'Windows' | 'macOS' | 'Linux' {
+  // Modern API (Chromium 90+)
+  const uaData = (navigator as any).userAgentData;
+  if (uaData?.platform) {
+    const platform = uaData.platform.toLowerCase();
+    if (platform.includes('windows') || platform === 'win32') return 'Windows';
+    if (platform.includes('macos') || platform === 'macos') return 'macOS';
+    return 'Linux';
+  }
+
+  // Fallback: navigator.platform (deprecated but widely supported)
+  const platform = (navigator.platform || '').toLowerCase();
+  if (platform.startsWith('win')) return 'Windows';
+  if (platform.startsWith('mac') || platform.startsWith('iphone') || platform.startsWith('ipad')) return 'macOS';
+  if (platform.includes('linux') || platform.includes('x11')) return 'Linux';
+
+  // Last resort: user-agent string
+  const ua = navigator.userAgent.toLowerCase();
+  if (ua.includes('windows') || ua.includes('win64') || ua.includes('win32')) return 'Windows';
+  if (ua.includes('macintosh') || ua.includes('mac os x') || ua.includes('macos')) return 'macOS';
+  return 'Linux';
+}
+
+function DownloadsContent() {
+  const [detectedOS, setDetectedOS] = useState<'Windows' | 'macOS' | 'Linux'>(() => detectOS());
+
+  const recommendedOption = downloadOptions.find((opt) => opt.os === detectedOS);
+  const otherOptions = downloadOptions.filter((opt) => opt.os !== detectedOS);
+
+  return (
+    <main className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+      {recommendedOption && (
+        <section className="mb-16">
+          <h2 className="mb-8 text-center text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+            Based on your system
+          </h2>
+          <div className="flex justify-center">
+            <DownloadCard option={recommendedOption} isRecommended={true} />
+          </div>
+        </section>
+      )}
+
+      <section>
+        <h2 className="mb-8 text-center text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+          Downloads for other platforms
+        </h2>
+        <div className="flex flex-wrap justify-center gap-8">
+          {otherOptions.map((option) => (
+            <DownloadCard key={option.os} option={option} />
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export default function Downloads() {
+  return (
+    <Layout title={headerData.title} description={headerData.subtitle}>
+      <header className="bg-gradient-to-r from-blue-500 to-purple-700 py-16 dark:from-blue-700 dark:to-purple-900">
+        <div className="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
+          <h1 className="mb-4 text-4xl font-extrabold text-white sm:text-5xl lg:text-6xl">{headerData.title}</h1>
+          <p className="mx-auto max-w-2xl text-xl text-blue-100">{headerData.subtitle}</p>
+        </div>
+      </header>
+
+      <BrowserOnly fallback={
+        <main className="mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
+          <div className="flex flex-wrap justify-center gap-8">
+            {downloadOptions.map((option) => (
+              <DownloadCard key={option.os} option={option} />
+            ))}
+          </div>
+        </main>
+      }>
+        {() => <DownloadsContent />}
+      </BrowserOnly>
+    </Layout>
+  );
+}
+

--- a/static/data/downloads.ts
+++ b/static/data/downloads.ts
@@ -1,0 +1,71 @@
+export interface DownloadOption {
+  os: 'Windows' | 'macOS' | 'Linux';
+  title: string;
+  description: string;
+  icon: string;
+  cli: {
+    url: string;
+    label: string;
+    instructionsUrl?: string;
+  };
+  desktop: {
+    url: string;
+    label: string;
+    instructionsUrl?: string;
+  };
+}
+
+export const downloadOptions: DownloadOption[] = [
+  {
+    os: 'Windows',
+    title: 'Windows',
+    description: 'Download Podman for Windows 10 and 11',
+    icon: 'fa6-brands:windows',
+    cli: {
+      url: 'https://github.com/containers/podman/releases/latest/download/podman-setup.exe',
+      label: 'Download Podman CLI (.exe)',
+      instructionsUrl: 'https://podman.io/docs/installation#windows',
+    },
+    desktop: {
+      url: 'https://podman-desktop.io/api/update/win32/latest',
+      label: 'Download Podman Desktop (.exe)',
+      instructionsUrl: 'https://podman-desktop.io/downloads#windows',
+    },
+  },
+  {
+    os: 'macOS',
+    title: 'macOS',
+    description: 'Download Podman for Apple Silicon (M1/M2) or Intel Macs',
+    icon: 'fa6-brands:apple',
+    cli: {
+      url: 'https://github.com/containers/podman/releases/latest/download/podman-installer-macos-amd64.pkg', // fallback URL, users might prefer brew
+      label: 'Download Podman CLI (.pkg)',
+      instructionsUrl: 'https://podman.io/docs/installation#macos',
+    },
+    desktop: {
+      url: 'https://podman-desktop.io/api/update/darwin/arm64/latest',
+      label: 'Download Podman Desktop Universal',
+      instructionsUrl: 'https://podman-desktop.io/downloads#macos',
+    },
+  },
+  {
+    os: 'Linux',
+    title: 'Linux',
+    description: 'Install Podman via your package manager',
+    icon: 'fa6-brands:linux',
+    cli: {
+      url: 'https://podman.io/docs/installation#linux',
+      label: 'View CLI Installation Instructions',
+    },
+    desktop: {
+      url: 'https://podman-desktop.io/api/update/linux/latest',
+      label: 'Download Podman Desktop Flatpak',
+      instructionsUrl: 'https://podman-desktop.io/downloads#linux',
+    },
+  },
+];
+
+export const headerData = {
+  title: 'Download Podman',
+  subtitle: 'Get Podman CLI and Podman Desktop for your operating system.',
+};


### PR DESCRIPTION
Hi,mentors- @ashley-cui @TomSweeneyRedHat
Implements a dedicated `/downloads` page that makes it easy for users to find the right Podman download for their platform, with intelligent OS auto‑detection.
## Changes
### New Files
- **`src/pages/downloads.tsx`** – New page that:
  - Detects the user’s OS (Windows/macOS/Linux) via a 3‑tier approach:
    1. `navigator.userAgentData.platform`
    2. `navigator.platform`
    3. `navigator.userAgent` regex fallback
  - Is wrapped in `<BrowserOnly>` for SSR safety.
  - Shows a highlighted card for the detected OS and a grid for the remaining platforms.
  - Provides download buttons for **Podman Desktop** and **Podman CLI** plus links to install instructions.
- **`static/data/downloads.ts`** – Data file defining icons, titles, URLs, and instructions for each platform, making future updates trivial.
### Modified Files
- **`docusaurus.config.js`** – Added a **Downloads** entry to the top navigation bar.
- **`src/css/main.css`** – Updated typography to use Docusaurus CSS variables (`--ifm-heading-color`, `--ifm-font-color-base`) so text is always visible in both Light and Dark modes.
- **`src/pages/downloads.tsx`** – (new file) includes the UI and logic described above.
## Verification Steps
- [x] Navigate to `http://localhost:3000/downloads` – the page loads correctly.
- [x] Run `yarn start` – the dev server starts without errors.
- [x] Spoof User‑Agent in DevTools (Windows/macOS/Linux) – the “Based on your system” card updates accordingly.
- [x] Toggle Light/Dark mode – all text, headings, and buttons retain proper contrast.
- [x] Run `yarn build` – the production build succeeds with no SSR/hydration warnings.
<img width="1893" height="854" alt="Screenshot 2026-08-17 221231" src="https://github.com/user-attachments/assets/52935cce-7f64-4b87-b7de-d64178abbb49" />
Closes #707
