### PR TITLE
fix(security): add rel="noopener noreferrer" to links opening a new tab

### DIFF
--- a/blog/2018-10-10-checkpoint-restore.md
+++ b/blog/2018-10-10-checkpoint-restore.md
@@ -135,7 +135,7 @@ life.
 
 I recorded all those steps in the demo below:
 
-<a href="https://asciinema.org/a/FsTbx9mZkzeuhCM2pFOr1tujM" target="_blank"><img src="https://asciinema.org/a/FsTbx9mZkzeuhCM2pFOr1tujM.png" width="650"/></a>
+<a href="https://asciinema.org/a/FsTbx9mZkzeuhCM2pFOr1tujM" target="_blank" rel="noopener noreferrer"><img src="https://asciinema.org/a/FsTbx9mZkzeuhCM2pFOr1tujM.png" width="650"/></a>
 
 The checkpoint/restore support in Podman is still very new and requires a git
 checkout of CRIU using the `criu-dev` branch to work right now. The necessary

--- a/src/components/content/ThankYouSection/index.tsx
+++ b/src/components/content/ThankYouSection/index.tsx
@@ -33,42 +33,49 @@ function ThankYouSection(): JSX.Element {
           <a
             href={redHat.href}
             target="_blank"
+            rel="noopener noreferrer"
             className="mx-4 mb-4 inline-block rounded-md p-4  dark:bg-gray-100 lg:row-span-2 lg:row-start-1 lg:mb-0">
             <img {...redHat} className="mx-auto p-4" />
           </a>
           <a
             href={amadeus.href}
             target="_blank"
+            rel="noopener noreferrer"
             className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
             <img {...amadeus} className="object-fit mx-auto max-w-sm p-4 " />
           </a>
           <a
             href={suse.href}
             target="_blank"
+            rel="noopener noreferrer"
             className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
             <img {...suse} className="object-fit mx-auto max-w-sm p-4 " />
           </a>
           <a
             href={motorola.href}
             target="_blank"
+            rel="noopener noreferrer"
             className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:row-span-2 lg:row-start-1 lg:mb-0">
             <img {...motorola} className="mx-auto p-4" />
           </a>
           <a
             href={ntt.href}
             target="_blank"
+            rel="noopener noreferrer"
             className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
             <img {...ntt} className="object-fit mx-auto max-w-sm p-4 " />
           </a>
           <a
             href={ibm.href}
             target="_blank"
+            rel="noopener noreferrer"
             className="col-span-3 mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:mb-0 lg:flex lg:h-28 lg:w-80 lg:items-center">
             <img {...ibm} className="object-fit mx-auto max-w-sm p-4 " />
           </a>
           <a
             href={debian.href}
             target="_blank"
+            rel="noopener noreferrer"
             className="mx-4 mb-4 inline-block rounded-md p-4 dark:bg-gray-100 lg:row-span-2 lg:row-start-1 lg:mb-0">
             <img {...debian} className="mx-auto p-4" />
           </a>

--- a/src/components/ui/ArticleCard/index.tsx
+++ b/src/components/ui/ArticleCard/index.tsx
@@ -53,6 +53,7 @@ function ArticleCard(props: ArticleCardProps) {
                 <a
                   href={props.path}
                   target="_blank"
+                  rel="noopener noreferrer"
                   className="text-white no-underline hover:text-blue-100 hover:no-underline dark:text-white dark:hover:text-blue-50">
                   {sanitizeHtml(props.title)}
                 </a>
@@ -83,6 +84,7 @@ function ArticleCard(props: ArticleCardProps) {
             <a
               href={props.path}
               target="_blank"
+              rel="noopener noreferrer"
               className="text-white no-underline hover:text-blue-100 hover:no-underline dark:text-white dark:hover:text-blue-50">
               {sanitizeHtml(props.title)}
             </a>

--- a/src/components/ui/Testimonial/index.tsx
+++ b/src/components/ui/Testimonial/index.tsx
@@ -31,7 +31,11 @@ function Testimonial(props: TestimonialProps) {
       </div>
       <div className="mt-2 mb-4 truncate">
         <p className="whitespace-normal text-gray-900 dark:text-gray-300 leading-snug mb-2">{props.description}</p>
-        {props.featuredlink && <a target="_blank" href={props.featuredlink}>{props.featuredlink}</a>}
+        {props.featuredlink && (
+          <a target="_blank" rel="noopener noreferrer" href={props.featuredlink}>
+            {props.featuredlink}
+          </a>
+        )}
       </div>
       <div className="mt-auto self-start text-gray-300 dark:text-gray-700 italic">
         <a href={props.path} className="text-gray-300 dark:text-gray-700 dark:hover:text-gray-700 no-underline hover:no-underline hover:bg-purple-300">

--- a/src/components/utilities/Link/index.tsx
+++ b/src/components/utilities/Link/index.tsx
@@ -6,6 +6,7 @@ export type LinkProps = Link & {
   hoverColor?: string;
   underline?: string;
   target?: string;
+  rel?: string;
 };
 function Link({
   text,
@@ -14,12 +15,16 @@ function Link({
   textColor = 'text-blue-700 dark:text-blue-500',
   hoverColor = 'hover:text-purple-700 hover:dark:text-purple-700',
   underline = 'underline underline-offset-4',
-  target = '_self'
+  target = '_self',
+  rel,
 }: LinkProps): JSX.Element {
+  /* Links opening a new tab must not hand window.opener to the target page */
+  const relationship = rel ?? (target === '_blank' ? 'noopener noreferrer' : undefined);
   return (
     <a
       href={path}
       target={target}
+      rel={relationship}
       className={`${fontSize} ${textColor} ${hoverColor} ${underline} cursor-pointer transition duration-150 ease-in`}>
       {text}
     </a>


### PR DESCRIPTION
#### Concisely describe the change

External links that open in a new tab were missing a `rel` attribute. When a link uses `target="_blank"` with no `rel`, the page that opens gets a working `window.opener` handle back to podman.io and can navigate the original tab somewhere else. That is reverse tabnabbing, and it also leaks the referrer.

On `main` there are 12 `target="_blank"` links under `src/`, and only one of them (`BlogArticlesList`) sets `rel`.

The root of it is the shared `Link` utility in `src/components/utilities/Link/index.tsx`. It accepts a `target` prop but never rendered `rel`, so any caller passing `target="_blank"` was affected. The 404 page does exactly that. I changed `Link` to default `rel` to `noopener noreferrer` when `target` is `_blank`, and a caller can still pass its own `rel` if it needs something different. Fixing it there covers the current caller and any future one, rather than leaving the next person to remember.

The rest are plain `<a>` tags and are fixed directly:

- `ThankYouSection` - the seven sponsor logo links
- `ArticleCard` - both article links. These open URLs that come back from the `blog.podman.io` API, so I would least want those left open.
- `Testimonial` - the featured link
- `blog/2018-10-10-checkpoint-restore.md` - one asciinema link

`BlogArticlesList` already set `rel` correctly and is not touched. No styling, markup structure, or behaviour changes beyond the added attribute.

Fixes: #671
Fixes: #576

#### Before screenshot / screen recording

Not a visual change, so there is nothing useful to screenshot. On `main`:

```
$ grep -rEc "target=[\"']_blank[\"']" src/ | awk -F: '{s+=$2} END{print s}'
12
$ grep -rc 'rel="noopener noreferrer"' src/ | awk -F: '{s+=$2} END{print s}'
1
```

#### After screenshot / screen recording

With this branch, the same count is 11 literal occurrences plus the 404 page link, which now gets `rel` from the `Link` component at render time.

I checked the generated HTML rather than just the source. After `yarn build`, across every page in `build/`:

```
$ grep -rohE '<a[^>]*target="_blank"[^>]*>' build --include=*.html | wc -l
10630
$ grep -rohE '<a[^>]*target="_blank"[^>]*>' build --include=*.html | grep -vc 'noopener'
0
```

For example the 404 page link, which is the one that goes through `Link`:

```html
<a href="" target="_blank" rel="noopener noreferrer" class="font-bold text-blue-700 ...">
```

and a sponsor logo:

```html
<a href="https://www.suse.com" target="_blank" rel="noopener noreferrer" class="mx-4 mb-4 inline-block ...">
```

`yarn build` completes successfully and `build/index.html` is produced, which is what the PR workflow checks.

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:

- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/containers/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)

@TomSweeneyRedHat @ashley-cui when you get a chance, could one of you take a look? Happy to split the `Link` change out into its own commit if you would rather review it separately.
